### PR TITLE
testing git - advertising hub

### DIFF
--- a/Tests/Git/sbinet/my-file.txt
+++ b/Tests/Git/sbinet/my-file.txt
@@ -1,0 +1,28 @@
+interesting tuto.
+I'd recommand using the nice "hub" command to interact with github.
+https://hub.github.com/
+
+it's a Go-based command.
+you can install it like so on lxplus:
+$ export GOPATH=$HOME/dev
+$ export PATH=$GOPATH/bin:$PATH
+
+$ go get github.com/github/hub
+$ which hub
+~binet/dev/bin/hub
+
+$ hub --version
+git version 2.2.2
+hub version 2.2.0-rc1
+
+The tutorial would then look like:
+
+$ hub clone HEP-FCC/FCCSW FCCSW
+$ cd FCCSW
+$ hub fork
+$ hub co -b my-git-test master
+$ ### edit ###
+$ hub add Tests/Git/USER/my-file.txt
+$ hub ci -m "testing git"
+$ hub push USER my-git-test
+$ hub pull-request


### PR DESCRIPTION
Advertising the 'hub' command for an almost full-terminal experience wrt handling github workflow.
https://hub.github.com/


it's a Go-based command.
you can install it like so on lxplus:
```sh
$ export GOPATH=$HOME/dev
$ export PATH=$GOPATH/bin:$PATH

$ go get github.com/github/hub
$ which hub
~binet/dev/bin/hub

$ hub --version
git version 2.2.2
hub version 2.2.0-rc1
```

The tutorial would then look like:

```sh
$ hub clone HEP-FCC/FCCSW FCCSW
$ cd FCCSW
$ hub fork
$ hub co -b my-git-test master
$ ### edit ###
$ hub add Tests/Git/USER/my-file.txt
$ hub ci -m "testing git"
$ hub push USER my-git-test
$ hub pull-request
```

FYI, I put the `hub` binary under `~binet/public/sw/bin`