### PR TITLE
Fixing examples and updating README

### DIFF
--- a/Examples/config/delphes_simulation.py
+++ b/Examples/config/delphes_simulation.py
@@ -10,15 +10,15 @@ delphessimulation = DelphesSimulation("Simulation", filename="/afs/cern.ch/user/
 #delphessimulation = DelphesSimulation("Simulation", filename="example_MyPythia.dat" , detectorcard = "Simulation/examples/delphes_card_FCC_basic.tcl" , outputcollections =  [ "ElectronEnergySmearing/electrons", "MuonMomentumSmearing/muons",  "JetEnergyScale/jets",  "MissingET/momentum", "ScalarHT/energy" ] )
 
 # we shouls add b-jets and track inpact parameters, fixme
-delphessimulation.Outputs.genparticles.Path = "genparticles"
-delphessimulation.Outputs.particles.Path = "particles"
-delphessimulation.Outputs.partons.Path = "partons"
-delphessimulation.Outputs.muons.Path = "muons"
-delphessimulation.Outputs.electrons.Path = "electrons"
-delphessimulation.Outputs.photons.Path = "photons"
-delphessimulation.Outputs.jets.Path = "jets"
-delphessimulation.Outputs.mets.Path = "met"
-delphessimulation.Outputs.hts.Path = "ht"
+delphessimulation.DataOutputs.genparticles.Path = "genparticles"
+delphessimulation.DataOutputs.particles.Path = "particles"
+delphessimulation.DataOutputs.partons.Path = "partons"
+delphessimulation.DataOutputs.muons.Path = "muons"
+delphessimulation.DataOutputs.electrons.Path = "electrons"
+delphessimulation.DataOutputs.photons.Path = "photons"
+delphessimulation.DataOutputs.jets.Path = "jets"
+delphessimulation.DataOutputs.mets.Path = "met"
+delphessimulation.DataOutputs.hts.Path = "ht"
 
 
 out = AlbersOutput("out",
@@ -36,7 +36,7 @@ out.outputCommands = ["drop *",
 
 ]
 
-ApplicationMgr( 
+ApplicationMgr(
     TopAlg = [
               delphessimulation,
               out

--- a/Examples/config/dummy_simulation.py
+++ b/Examples/config/dummy_simulation.py
@@ -9,39 +9,39 @@ from Configurables import HepMCReader
 reader = HepMCReader("Reader", Filename="example_MyPythia.dat")
 # have a look at the source code of HepMCReader, in Generation/src/HepMCReader
 # In the following line,
-#   reader.Outputs.YYY.Path = "ZZZ"
+#   reader.DataOutputs.YYY.Path = "ZZZ"
 # YYY matches the string passed to declareOutput in the constructor of the algorithm
 # XXX declares a name for the product (the HepMC::GenEvent)
-reader.Outputs.hepmc.Path = "hepmc"
+reader.DataOutputs.hepmc.Path = "hepmc"
 
 # reads an HepMC::GenEvent from the data service and writes
 # a collection of EDM Particles
 from Configurables import HepMCConverter
 hepmc_converter = HepMCConverter("Converter")
 # the input product name matches the output product name of the previous module
-hepmc_converter.Inputs.hepmc.Path="hepmc"
-hepmc_converter.Outputs.genparticles.Path="all_genparticles"
+hepmc_converter.DataInputs.hepmc.Path="hepmc"
+hepmc_converter.DataOutputs.genparticles.Path="all_genparticles"
 hepmc_converter.DataOutputs.genvertices.Path="all_genvertices"
 
 from Configurables import GenParticleFilter
 genfilter = GenParticleFilter("StableParticles")
-genfilter.Inputs.genparticles.Path = "all_genparticles"
-genfilter.Outputs.genparticles.Path = "genparticles"
+genfilter.DataInputs.genparticles.Path = "all_genparticles"
+genfilter.DataOutputs.genparticles.Path = "genparticles"
 
 from Configurables import JetClustering_MCParticleCollection_GenJetCollection_GenJetParticleAssociationCollection_ as GenJetClustering
 genjet_clustering = GenJetClustering(
     "GenJetClustering",
     verbose=False
     )
-genjet_clustering.Inputs.particles.Path='genparticles'
+genjet_clustering.DataInputs.particles.Path='genparticles'
 # giving a meaningful name for the output product
-genjet_clustering.Outputs.jets.Path='genjets'
-genjet_clustering.Outputs.constituents.Path='genjets_particles'
+genjet_clustering.DataOutputs.jets.Path='genjets'
+genjet_clustering.DataOutputs.constituents.Path='genjets_particles'
 
 from Configurables import DummySimulation
 dummysimulation = DummySimulation("Simulation")
-dummysimulation.Inputs.genparticles.Path = "genparticles"
-dummysimulation.Outputs.particles.Path = "particles"
+dummysimulation.DataInputs.genparticles.Path = "genparticles"
+dummysimulation.DataOutputs.particles.Path = "particles"
 
 # reads EDM Particles and creates EDM jets
 from Configurables import JetClustering_ParticleCollection_JetCollection_JetParticleAssociationCollection_ as JetClustering
@@ -49,10 +49,10 @@ jet_clustering = JetClustering(
     "JetClustering",
     verbose=False
     )
-jet_clustering.Inputs.particles.Path='particles'
+jet_clustering.DataInputs.particles.Path='particles'
 # giving a meaningful name for the output product
-jet_clustering.Outputs.jets.Path='jets'
-jet_clustering.Outputs.constituents.Path='jets_particles'
+jet_clustering.DataOutputs.jets.Path='jets'
+jet_clustering.DataOutputs.constituents.Path='jets_particles'
 
 out = AlbersOutput("out",
                    OutputLevel=DEBUG)

--- a/Examples/config/dummy_simulation.py
+++ b/Examples/config/dummy_simulation.py
@@ -8,19 +8,20 @@ albersevent   = FCCDataSvc("EventDataSvc")
 from Configurables import HepMCReader
 reader = HepMCReader("Reader", Filename="example_MyPythia.dat")
 # have a look at the source code of HepMCReader, in Generation/src/HepMCReader
-# In the following line, 
+# In the following line,
 #   reader.Outputs.YYY.Path = "ZZZ"
 # YYY matches the string passed to declareOutput in the constructor of the algorithm
-# XXX declares a name for the product (the HepMC::GenEvent)    
+# XXX declares a name for the product (the HepMC::GenEvent)
 reader.Outputs.hepmc.Path = "hepmc"
 
-# reads an HepMC::GenEvent from the data service and writes 
-# a collection of EDM Particles 
+# reads an HepMC::GenEvent from the data service and writes
+# a collection of EDM Particles
 from Configurables import HepMCConverter
 hepmc_converter = HepMCConverter("Converter")
 # the input product name matches the output product name of the previous module
 hepmc_converter.Inputs.hepmc.Path="hepmc"
 hepmc_converter.Outputs.genparticles.Path="all_genparticles"
+hepmc_converter.DataOutputs.genvertices.Path="all_genvertices"
 
 from Configurables import GenParticleFilter
 genfilter = GenParticleFilter("StableParticles")
@@ -59,11 +60,11 @@ out.outputCommands = ["drop *",
                       "keep *jets*",
                       "keep particles"]
 
-ApplicationMgr( 
+ApplicationMgr(
     TopAlg = [reader,hepmc_converter,genfilter,
 #              genjet_clustering,
               dummysimulation,
-              jet_clustering, 
+              jet_clustering,
               out
               ],
     EvtSel = 'NONE',

--- a/Generation/config/particleGun.py
+++ b/Generation/config/particleGun.py
@@ -3,14 +3,14 @@ from Configurables import ApplicationMgr, THistSvc, Gaudi__ParticlePropertySvc
 from Configurables import HepMCDumper, ParticleGunAlg, MomentumRangeParticleGun, HepMCHistograms, FlatSmearVertex
 
 dumper = HepMCDumper("Dumper")
-dumper.Inputs.hepmc.Path="hepmc"
+dumper.DataInputs.hepmc.Path="hepmc"
 
 particlePropertySvc = Gaudi__ParticlePropertySvc("ParticlePropertySvc")
 
 guntool = MomentumRangeParticleGun()
 
 gun = ParticleGunAlg("gun", ParticleGunTool = "MomentumRangeParticleGun", VertexSmearingTool = "FlatSmearVertex" )
-gun.Outputs.hepmc.Path = "hepmc"
+gun.DataOutputs.hepmc.Path = "hepmc"
 
 gun.addTool(FlatSmearVertex, name="FlatSmearVertex")
 
@@ -22,7 +22,7 @@ gun.FlatSmearVertex.zVertexMin = -30
 gun.FlatSmearVertex.zVertexMax = 30
 
 histo = HepMCHistograms("GenHistograms")
-histo.Inputs.hepmc.Path="hepmc"
+histo.DataInputs.hepmc.Path="hepmc"
 
 THistSvc().Output = ["rec DATAFILE='GenHistograms.root' TYP='ROOT' OPT='RECREATE'"]
 THistSvc().PrintAll=True

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This software is based on Gaudi.
 Working with GitHub
 -------------------
 
-In this section, you will first find a description of our github organization and workflow. 
-Then, you will find instructions for setting up your github account, and taking part in this workflow. 
+In this section, you will first find a description of our github organization and workflow.
+Then, you will find instructions for setting up your github account, and taking part in this workflow.
 
 ### Organization and workflow
 
@@ -19,14 +19,14 @@ Then, you will find instructions for setting up your github account, and taking 
     * FCCSW-ee : to be created
     * FCCSW-eh : to be created
 
-* Individual github users do not directly push their code to the FCC repositories. Instead, they make ("fork") their own copy of the FCC repositories on github. Then, they: 
+* Individual github users do not directly push their code to the FCC repositories. Instead, they make ("fork") their own copy of the FCC repositories on github. Then, they:
     * develop and commit on their local machine
     * push their code to their copy of the FCC repositories on github
-    * send pull requests to the FCC organization. The FCC organization administrators are then free to pull the code from the user repositories or not, thus taking the responsibility of the software integrity for the organization. 
+    * send pull requests to the FCC organization. The FCC organization administrators are then free to pull the code from the user repositories or not, thus taking the responsibility of the software integrity for the organization.
 
-### Instructions for new users 
+### Instructions for new users
 
-1. create a github account if you don't have one. 
+1. create a github account if you don't have one.
 2. go to https://github.com/HEP-FCC/FCCSW and click "Fork" at the top right of the page. You are directed to your newly forked copy of the FCCSW repository
 3. in the instructions below, replace \<username\> by your github username
 
@@ -34,12 +34,12 @@ Then, you will find instructions for setting up your github account, and taking 
 Installation
 ------------
 
-Log in to lxplus SLC6. Please note that these instructions might not work on another SLC6 machine. Instructions to compile on a mac are in preparation. 
+Log in to lxplus SLC6. Please note that these instructions might not work on another SLC6 machine. Instructions to compile on a mac are in preparation.
 
 Clone the FCCSW repository: **replace \<username\> by your github username**
 
-    git clone git@github.com:<username>/FCCSW.git FCCSW 
-    export FCCSW=$FCCBASE/FCCSW
+    git clone git@github.com:<username>/FCCSW.git FCCSW
+    export FCCSW=$PWD/FCCSW
 
 Set up your environment:
 
@@ -56,5 +56,5 @@ Test
     cp ~hegner/public/example_MyPythia.dat .
     ./run gaudirun.py config/example_options.py
 
-You should see an HepMC printout. 
+You should see an HepMC printout.
 

--- a/Reconstruction/config/genJetClustering.py
+++ b/Reconstruction/config/genJetClustering.py
@@ -3,24 +3,24 @@ from Configurables import ApplicationMgr, HepMCReader, HepMCDumper, HepMCJetClus
 from Configurables import HepMCHistograms, JetHistograms
 
 reader = HepMCReader("Reader", Filename="pythia.dat")
-reader.Outputs.hepmc.Path = "hepmc"
+reader.DataOutputs.hepmc.Path = "hepmc"
 
 dumper = HepMCDumper("Dumper")
-dumper.Inputs.hepmc.Path="hepmc"
+dumper.DataInputs.hepmc.Path="hepmc"
 
 genHisto = HepMCHistograms("GenHistograms")
-genHisto.Inputs.hepmc.Path="hepmc"
+genHisto.DataInputs.hepmc.Path="hepmc"
 
 jets = HepMCJetClustering("ktCluster")
 jets.JetAlgorithm = "kt"
 jets.RecominbationScheme = "E"
 jets.ConeRadius = 0.7
 jets.PtMin = 1
-jets.Inputs.hepmc.Path="hepmc"
-jets.Outputs.jets.Path="ktJets"
+jets.DataInputs.hepmc.Path="hepmc"
+jets.DataOutputs.jets.Path="ktJets"
 
 jetHisto = JetHistograms("JetHistograms")
-jetHisto.Inputs.jets.Path="ktJets"
+jetHisto.DataInputs.jets.Path="ktJets"
 
 THistSvc().Output = ["rec DATAFILE='GenHistograms.root' TYP='ROOT' OPT='RECREATE'"]
 THistSvc().PrintAll=True

--- a/cmake/FindDelphes.cmake
+++ b/cmake/FindDelphes.cmake
@@ -1,4 +1,4 @@
-set(searchpath ${DELPHES_DIR}  ${DELPHES_DIR}/external )
+set(searchpath ${DELPHES_DIR} ${DELPHES_DIR}/external ${DELPHES_DIR}/lib ${DELPHES_DIR}/include)
 
 
 find_library(DELPHES_LIBRARY
@@ -8,13 +8,13 @@ find_library(DELPHES_LIBRARY
 
 find_path(DELPHES_INCLUDE_DIR
         #   NAMES DelphesClasses.h Delphes.h
-           NAMES classes/DelphesClasses.h modules/Delphes.h external/ExRootAnalysis 
+           NAMES classes/DelphesClasses.h modules/Delphes.h external/ExRootAnalysis
            HINTS ${searchpath}
            PATH_SUFFIXES include)
 
 find_path(DELPHES_EXTERNALS_INCLUDE_DIR
              #   NAMES DelphesClasses.h Delphes.h
-           NAMES external/ExRootAnalysis/ExRootConfReader.h
+           NAMES ExRootAnalysis/ExRootConfReader.h
            HINTS ${searchpath}
            PATH_SUFFIXES include
 )
@@ -22,7 +22,7 @@ find_path(DELPHES_EXTERNALS_INCLUDE_DIR
 
 unset(searchpath)
 
-set(DELPHES_INCLUDE_DIRS ${DELPHES_INCLUDE_DIR} ${DELPHES_INCLUDE_DIR}/external)
+set(DELPHES_INCLUDE_DIRS ${DELPHES_INCLUDE_DIR} ${DELPHES_EXTERNALS_INCLUDE_DIR})
 set(DELPHES_EXTERNALS_INCLUDE_DIRS ${DELPHES_EXTERNALS_INCLUDE_DIR})
 set(DELPHES_LIBRARIES ${DELPHES_LIBRARY})
 

--- a/cmake/GaudiBuildFlags.cmake
+++ b/cmake/GaudiBuildFlags.cmake
@@ -1,0 +1,330 @@
+# define a minimun default version
+set(GAUDI_CXX_STANDARD_DEFAULT "c++11")
+# overriddend depending on the compiler
+if (LCG_COMP STREQUAL "clang" AND LCG_COMPVERS VERSION_EQUAL "37")
+  set(GAUDI_CXX_STANDARD_DEFAULT "c++14")
+elseif(LCG_COMP STREQUAL "gcc")
+  # Special defaults
+  if (LCG_COMPVERS VERSION_LESS "47")
+    set(GAUDI_CXX_STANDARD_DEFAULT "c++98")
+  elseif(LCG_COMPVERS VERSION_LESS "49")
+    # C++11 is enable by default on 4.7 <= gcc < 4.9
+    set(GAUDI_CXX_STANDARD_DEFAULT "c++11")
+  elseif(LCG_COMPVERS VERSION_LESS "51")
+    # C++1y (C++14 preview) is enable by default on 4.9 <= gcc < 5.1
+    set(GAUDI_CXX_STANDARD_DEFAULT "c++1y")
+  else()
+    # C++14 is enable by default on gcc >= 5.1
+    set(GAUDI_CXX_STANDARD_DEFAULT "c++14")
+    # we are not ready for the new c++11 ABI (because of llvm in ROOT)
+    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+  endif()
+endif()
+# special for GaudiHive
+set(GAUDI_CPP11_DEFAULT ON)
+
+#--- Gaudi Build Options -------------------------------------------------------
+# Build options that map to compile time features
+#
+option(GAUDI_V21
+       "disable backward compatibility hacks (implies all G21_* options)"
+       OFF)
+option(G21_HIDE_SYMBOLS
+       "enable explicit symbol visibility on gcc-4"
+       OFF)
+option(G21_NEW_INTERFACES
+       "disable backward-compatibility hacks in IInterface and InterfaceID"
+       OFF)
+option(G21_NO_ENDREQ
+       "disable the 'endreq' stream modifier (use 'endmsg' instead)"
+       OFF)
+option(G21_NO_DEPRECATED
+       "remove deprecated methods and functions"
+       OFF)
+option(G22_NEW_SVCLOCATOR
+       "use (only) the new interface of the ServiceLocator"
+       OFF)
+option(GAUDI_V22
+       "enable some API extensions"
+       OFF)
+
+option(GAUDI_CMT_RELEASE
+       "use CMT deafult release flags instead of the CMake ones"
+       ON)
+
+if(BINARY_TAG MATCHES "-do0$")
+  set(GAUDI_SLOW_DEBUG_DEFAULT ON)
+else()
+  set(GAUDI_SLOW_DEBUG_DEFAULT OFF)
+endif()
+option(GAUDI_SLOW_DEBUG
+       "turn off all optimizations in debug builds"
+       ${GAUDI_SLOW_DEBUG_DEFAULT})
+
+if(DEFINED GAUDI_CPP11)
+  message(WARNING "GAUDI_CPP11 is an obsolete option, use GAUDI_CXX_STANDARD=c++11 instead")
+endif()
+
+set(GAUDI_CXX_STANDARD "${GAUDI_CXX_STANDARD_DEFAULT}"
+    CACHE STRING "Version of the C++ standard to be used.")
+
+#--- Compilation Flags ---------------------------------------------------------
+add_definitions(-DGOD_NOALLOC)
+if(NOT GAUDI_FLAGS_SET)
+  #message(STATUS "Setting cached build flags")
+
+  if(MSVC90)
+
+    set(CMAKE_CXX_FLAGS_DEBUG "/D_NDEBUG /MD /Zi /Ob0 /Od /RTC1"
+        CACHE STRING "Flags used by the compiler during debug builds."
+        FORCE)
+    set(CMAKE_C_FLAGS_DEBUG "/D_NDEBUG /MD /Zi /Ob0 /Od /RTC1"
+        CACHE STRING "Flags used by the compiler during debug builds."
+        FORCE)
+
+    if(GAUDI_CMT_RELEASE)
+      set(CMAKE_CXX_FLAGS_RELEASE "/O2"
+          CACHE STRING "Flags used by the compiler during release builds."
+          FORCE)
+      set(CMAKE_C_FLAGS_RELEASE "/O2"
+          CACHE STRING "Flags used by the compiler during release builds."
+          FORCE)
+    endif()
+
+  else()
+
+    # Common compilation flags
+    set(CMAKE_CXX_FLAGS
+        "-fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -Wwrite-strings -Wpointer-arith -Woverloaded-virtual -Wno-long-long -Wno-shadow"
+        CACHE STRING "Flags used by the compiler during all build types."
+        FORCE)
+    set(CMAKE_C_FLAGS
+        "-fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -Wwrite-strings -Wpointer-arith -Wno-long-long"
+        CACHE STRING "Flags used by the compiler during all build types."
+        FORCE)
+    set(CMAKE_Fortran_FLAGS
+        "-fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -fsecond-underscore"
+        CACHE STRING "Flags used by the compiler during all build types."
+        FORCE)
+
+    # Build type compilation flags (if different from default or uknown to CMake)
+    if(GAUDI_CMT_RELEASE)
+      set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG"
+          CACHE STRING "Flags used by the compiler during release builds."
+          FORCE)
+      set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG"
+          CACHE STRING "Flags used by the compiler during release builds."
+          FORCE)
+      set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -DNDEBUG"
+          CACHE STRING "Flags used by the compiler during release builds."
+          FORCE)
+    endif()
+
+    if (LCG_COMP STREQUAL "gcc" AND LCG_COMPVERS VERSION_GREATER "47")
+      # Use -Og with Debug builds in gcc >= 4.8
+      set(CMAKE_CXX_FLAGS_DEBUG "-Og -g"
+          CACHE STRING "Flags used by the compiler during Debug builds."
+          FORCE)
+      set(CMAKE_C_FLAGS_DEBUG "-Og -g"
+          CACHE STRING "Flags used by the compiler during Debug builds."
+          FORCE)
+      set(CMAKE_Fortran_FLAGS_DEBUG "-Og -g"
+          CACHE STRING "Flags used by the compiler during Debug builds."
+          FORCE)
+    endif()
+
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG"
+        CACHE STRING "Flags used by the compiler during Release with Debug Info builds."
+        FORCE)
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG"
+        CACHE STRING "Flags used by the compiler during Release with Debug Info builds."
+        FORCE)
+    set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG"
+        CACHE STRING "Flags used by the compiler during Release with Debug Info builds."
+        FORCE)
+
+    set(CMAKE_CXX_FLAGS_COVERAGE "--coverage"
+        CACHE STRING "Flags used by the compiler during coverage builds."
+        FORCE)
+    set(CMAKE_C_FLAGS_COVERAGE "--coverage"
+        CACHE STRING "Flags used by the compiler during coverage builds."
+        FORCE)
+    set(CMAKE_Fortran_FLAGS_COVERAGE "--coverage"
+        CACHE STRING "Flags used by the compiler during coverage builds."
+        FORCE)
+
+    set(CMAKE_CXX_FLAGS_PROFILE "-pg"
+        CACHE STRING "Flags used by the compiler during profile builds."
+        FORCE)
+    set(CMAKE_C_FLAGS_PROFILE "-pg"
+        CACHE STRING "Flags used by the compiler during profile builds."
+        FORCE)
+    set(CMAKE_Fortran_FLAGS_PROFILE "-pg"
+        CACHE STRING "Flags used by the compiler during profile builds."
+        FORCE)
+
+
+    # The others are already marked as 'advanced' by CMake, these are custom.
+    mark_as_advanced(CMAKE_C_FLAGS_COVERAGE CMAKE_CXX_FLAGS_COVERAGE CMAKE_Fortran_FLAGS_COVERAGE
+                     CMAKE_C_FLAGS_PROFILE CMAKE_CXX_FLAGS_PROFILE CMAKE_Fortran_FLAGS_PROFILE)
+    mark_as_advanced(CMAKE_Fortran_COMPILER CMAKE_Fortran_FLAGS
+                     CMAKE_Fortran_FLAGS_RELEASE CMAKE_Fortran_FLAGS_RELWITHDEBINFO)
+
+  endif()
+
+  #--- Link shared flags -------------------------------------------------------
+  if (CMAKE_SYSTEM_NAME MATCHES Linux)
+    set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--as-needed -Wl,--no-undefined  -Wl,-z,max-page-size=0x1000"
+        CACHE STRING "Flags used by the linker during the creation of dll's."
+        FORCE)
+    set(CMAKE_MODULE_LINKER_FLAGS "-Wl,--as-needed -Wl,--no-undefined  -Wl,-z,max-page-size=0x1000"
+        CACHE STRING "Flags used by the linker during the creation of modules."
+        FORCE)
+    set(CMAKE_EXE_LINKER_FLAGS "-Wl,--as-needed -Wl,--no-undefined  -Wl,-z,max-page-size=0x1000"
+        CACHE STRING "Flags used by the linker during the creation of executables."
+        FORCE)
+  endif()
+
+  if(APPLE)
+    # special link options for MacOSX
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flat_namespace -undefined dynamic_lookup"
+        CACHE STRING "Flags used by the linker during the creation of dll's."
+        FORCE)
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -flat_namespace -undefined dynamic_lookup"
+        CACHE STRING "Flags used by the linker during the creation of modules."
+        FORCE)
+  endif()
+
+  # prevent resetting of the flags
+  set(GAUDI_FLAGS_SET ON
+      CACHE INTERNAL "flag to check if the compilation flags have already been set")
+endif()
+
+
+if(UNIX)
+  add_definitions(-D_GNU_SOURCE -Dunix -Df2cFortran)
+
+  if (CMAKE_SYSTEM_NAME MATCHES Linux)
+    add_definitions(-Dlinux)
+  endif()
+endif()
+
+if(MSVC90)
+  add_definitions(/wd4275 /wd4251 /wd4351)
+  add_definitions(-DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB)
+  add_definitions(/nologo)
+endif()
+
+if(APPLE)
+  # by default, CMake uses the option -bundle for modules, but we need -dynamiclib for them too
+  string(REPLACE "-bundle" "-dynamiclib" CMAKE_SHARED_MODULE_CREATE_C_FLAGS "${CMAKE_SHARED_MODULE_CREATE_C_FLAGS}")
+  string(REPLACE "-bundle" "-dynamiclib" CMAKE_SHARED_MODULE_CREATE_CXX_FLAGS "${CMAKE_SHARED_MODULE_CREATE_CXX_FLAGS}")
+endif()
+
+#--- Special build flags -------------------------------------------------------
+if ((GAUDI_V21 OR G21_HIDE_SYMBOLS) AND (LCG_COMP STREQUAL gcc AND LCG_COMPVERS MATCHES "4[0-9]"))
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
+endif()
+
+# handle options to choose the  version of the C++ standard
+string(TOLOWER "${GAUDI_CXX_STANDARD}" GAUDI_CXX_STANDARD)
+if(GAUDI_CXX_STANDARD STREQUAL "ansi")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ansi")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ansi")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=${GAUDI_CXX_STANDARD}")
+  if(NOT GAUDI_CXX_STANDARD STREQUAL "c++98")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
+  else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ansi")
+  endif()
+endif()
+
+if(LCG_COMP STREQUAL clang AND LCG_COMPVERS MATCHES "37")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -Wno-unused-local-typedefs --gcc-toolchain=${lcg_system_compiler_path}")
+endif()
+
+if(NOT GAUDI_V21)
+  if(GAUDI_V22)
+    add_definitions(-DGAUDI_V22_API)
+  else()
+    add_definitions(-DGAUDI_V20_COMPAT)
+  endif()
+  # special case
+  if(G21_HIDE_SYMBOLS AND (LCG_COMP STREQUAL gcc AND LCG_COMPVERS MATCHES "^4"))
+    add_definitions(-DG21_HIDE_SYMBOLS)
+  endif()
+  #
+  foreach (feature G21_NEW_INTERFACES G21_NO_ENDREQ G21_NO_DEPRECATED G22_NEW_SVCLOCATOR)
+    if (${feature})
+      add_definitions(-D${feature})
+    endif()
+  endforeach()
+endif()
+
+if (LCG_HOST_ARCH AND LCG_ARCH)
+  # this is valid only in the LCG toolchain context
+  if (LCG_HOST_ARCH STREQUAL x86_64 AND LCG_ARCH STREQUAL i686)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m32")
+    set(GCCXML_CXX_FLAGS "${GCCXML_CXX_FLAGS} -m32")
+  elseif(NOT LCG_HOST_ARCH STREQUAL LCG_ARCH)
+    message(FATAL_ERROR "Cannot build for ${LCG_ARCH} on ${LCG_HOST_ARCH}.")
+  endif()
+endif()
+
+#--- Tuning of warnings --------------------------------------------------------
+if(GAUDI_HIDE_WARNINGS)
+  if(LCG_COMP MATCHES clang)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wno-overloaded-virtual -Wno-char-subscripts -Wno-unused-parameter")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wno-empty-body")
+    if(LCG_COMPVERS MATCHES "48|49|max")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
+    endif()
+  endif()
+endif()
+
+if(GAUDI_SLOW_DEBUG)
+  string(REPLACE "-Og" "-O0" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  string(REPLACE "-Og" "-O0" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+  string(REPLACE "-Og" "-O0" CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}")
+endif()
+
+#--- Special flags -------------------------------------------------------------
+# FIXME: enforce the use of Boost Filesystem V3 to be compatible between 1.44 and 1.48
+add_definitions(-DBOOST_FILESYSTEM_VERSION=3)
+# FIXME: enforce the use of Boost Phoenix V3 (V2 does not work with recent compilers)
+#        see http://stackoverflow.com/q/20721486
+#        and http://stackoverflow.com/a/20440238/504346
+add_definitions(-DBOOST_SPIRIT_USE_PHOENIX_V3)
+
+if((LCG_COMP STREQUAL gcc AND LCG_COMPVERS MATCHES "47|max") OR GAUDI_CPP11)
+  set(GCCXML_CXX_FLAGS "${GCCXML_CXX_FLAGS} -D__STRICT_ANSI__")
+endif()
+
+if(LCG_COMP STREQUAL gcc AND LCG_COMPVERS STREQUAL 43)
+  # The -pedantic flag gives problems on GCC 4.3.
+  string(REPLACE "-pedantic" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  string(REPLACE "-pedantic" "" CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}")
+endif()
+
+if(GAUDI_ATLAS)
+  # FIXME: this macro is used in ATLAS to simplify the migration to Gaudi v25,
+  #        unfortunately it's not possible to detect the version of Gaudi at this point
+  #        so we assume that any CMake-based build in ATLAS uses Gaudi >= v25
+  add_definitions(-DHAVE_GAUDI_PLUGINSVC)
+
+  add_definitions(-DATLAS_GAUDI_V21)
+  add_definitions(-DATLAS)
+  include(AthenaBuildFlags OPTIONAL)
+else()
+  # FIXME: these macros are LHCb specific, but we do not have yet a way to set
+  # compile flags in a project, such that they are inherited by other projects.
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_definitions(-DGOD_NOALLOC)
+  endif()
+endif()
+
+add_definitions(-DG4MULTITHREADED)

--- a/config/simple_pythia.py
+++ b/config/simple_pythia.py
@@ -1,7 +1,7 @@
 """
 to run example
 > export PYTHIA8_XML=/afs/cern.ch/sw/lcg/releases/LCG_68/MCGenerators/pythia8/186/x86_64-slc6-gcc48-opt/xmldoc
-> ./run gaudirun.py simple_pythia.py 
+> ./run gaudirun.py simple_pythia.py
 """
 from Gaudi.Configuration import *
 
@@ -15,20 +15,21 @@ pythiafile="config/Pythia_standard.cmd"
 
 albersevent   = FCCDataSvc("EventDataSvc")
 
-from Configurables import PythiaInterface 
-# PythiaInterface parameter 
+from Configurables import PythiaInterface
+# PythiaInterface parameter
 #pythia8gen = PythiaInterface("Pythia8Interface",Filename="main03.cmnd")
 pythia8gen = PythiaInterface(Filename=pythiafile)
 # write the HepMC::GenEvent to the data service
 pythia8gen.DataOutputs.hepmc.Path = "hepmc"
 
 from Configurables import HepMCConverter
-# reads an HepMC::GenEvent from the data service and writes 
-# a collection of EDM Particles 
+# reads an HepMC::GenEvent from the data service and writes
+# a collection of EDM Particles
 hepmc_converter = HepMCConverter("Converter")
 # the input product name matches the output product name of the previous module
 hepmc_converter.DataInputs.hepmc.Path="hepmc"
 hepmc_converter.DataOutputs.genparticles.Path="all_genparticles"
+hepmc_converter.DataOutputs.genvertices.Path="all_genvertices"
 
 from Configurables import GenParticleFilter
 genfilter = GenParticleFilter("StableParticles")

--- a/config/simple_workflow.py
+++ b/config/simple_workflow.py
@@ -8,19 +8,20 @@ albersevent   = FCCDataSvc("EventDataSvc")
 from Configurables import HepMCReader
 reader = HepMCReader("Reader", Filename="example_MyPythia.dat")
 # have a look at the source code of HepMCReader, in Generation/src/HepMCReader
-# In the following line, 
+# In the following line,
 #   reader.DataOutputs.YYY.Path = "ZZZ"
 # YYY matches the string passed to declareOutput in the constructor of the algorithm
-# XXX declares a name for the product (the HepMC::GenEvent)    
+# XXX declares a name for the product (the HepMC::GenEvent)
 reader.DataOutputs.hepmc.Path = "hepmc"
 
-# reads an HepMC::GenEvent from the data service and writes 
-# a collection of EDM Particles 
+# reads an HepMC::GenEvent from the data service and writes
+# a collection of EDM Particles
 from Configurables import HepMCConverter
 hepmc_converter = HepMCConverter("Converter")
 # the input product name matches the output product name of the previous module
 hepmc_converter.DataInputs.hepmc.Path="hepmc"
 hepmc_converter.DataOutputs.genparticles.Path="all_genparticles"
+hepmc_converter.DataOutputs.genvertices.Path="all_genvertices"
 
 from Configurables import JetClustering_MCParticleCollection_GenJetCollection_GenJetParticleAssociationCollection_ as JetClustering
 genjet_clustering = JetClustering(
@@ -36,7 +37,7 @@ out = AlbersOutput("out",
                    OutputLevel=DEBUG)
 out.outputCommands = ["keep *"]
 
-ApplicationMgr( 
+ApplicationMgr(
     TopAlg = [reader,hepmc_converter,
               genjet_clustering,
               out

--- a/init.csh
+++ b/init.csh
@@ -1,26 +1,24 @@
 #!/usr/bin/csh
+source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r4p3/InstallArea/scripts/LbLogin.csh --cmtconfig x86_64-slc6-gcc49-opt
 
-if ! $?GAUDI then
-    echo "Need to set GAUDI environmental variable: setenv GAUDI $FCCBASE/GAUDI/GAUDI_v25r2"
-    exit 1
-else 
-    echo "Gaudi   :    $GAUDI"
-endif
+setenv FCCEDM /afs/cern.ch/exp/fcc/sw/0.5/fcc-edm/0.1/x86_64-slc6-gcc49-opt/
+setenv ALBERS /afs/cern.ch/exp/fcc/sw/0.5/albers-core/0.1/x86_64-slc6-gcc49-opt
+setenv DELPHES_DIR /afs/cern.ch/exp/fcc/sw/0.5/Delphes-3.3.1/x86_64-slc6-gcc49-opt
+setenv PYTHIA_DIR /afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-opt/
 
-if ! $?FCCBASE then
-    echo "Need to set the FCCBASE environment variable to root path of the software (contains both Gaudi and the FCC software)."
-    exit 1
-else 
-    echo "FCC root:    $FCCBASE"
-endif
-
-# set up CMake:
-setenv PATH /afs/cern.ch/sw/lcg/contrib/CMake/2.8.12.2/Linux-i386/bin:${PATH}
-setenv CMAKE_PREFIX_PATH ${GAUDI}/cmake:${FCCBASE}:/afs/cern.ch/sw/lcg/releases
-setenv CMTCONFIG x86_64-slc6-gcc48-opt
-
-# set up the compilers
-setenv PATH /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r0/InstallArea/scripts:${PATH}
+setenv CMAKE_PREFIX_PATH ${FCCEDM}:${ALBERS}:${DELPHES_DIR}:${CMAKE_PREFIX_PATH}:${PYTHIA_DIR}
 
 # set up Pythia8 Index.xml
-setenv PYTHIA8_XML /afs/cern.ch/sw/lcg/releases/LCG_68/MCGenerators/pythia8/186/x86_64-slc6-gcc48-opt/xmldoc
+setenv PYTHIA8_XML /afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-opt/share/Pythia8/xmldoc
+
+# add Geant4 data files
+source /afs/cern.ch/sw/lcg/external/geant4/10.1/setup_g4datasets.csh
+
+# add DD4hep
+setenv inithere ${PWD}
+cd /afs/cern.ch/exp/fcc/sw/0.5/DD4hep/20152311/x86_64-slc6-gcc49-opt
+source bin/thisdd4hep.csh
+cd $inithere
+
+setenv CMTPROJECTPATH /afs/cern.ch/exp/fcc/sw/0.5/
+source /afs/cern.ch/sw/lcg/contrib/gcc/4.9.3/x86_64-slc6/setup.csh

--- a/init.sh
+++ b/init.sh
@@ -9,7 +9,7 @@ export PYTHIA_DIR=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x
 export CMAKE_PREFIX_PATH=$FCCEDM:$ALBERS:$DELPHES_DIR:$CMAKE_PREFIX_PATH:$PYTHIA_DIR
 
 # set up Pythia8 Index.xml
-export PYTHIA8_XML=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-opt/xmldoc
+export PYTHIA8_XML=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-opt/share/Pythia8/xmldoc
 
 # add Geant4 data files
 source /afs/cern.ch/sw/lcg/external/geant4/10.1/setup_g4datasets.sh

--- a/init.sh
+++ b/init.sh
@@ -3,7 +3,7 @@ source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r4p3/InstallAre
 
 export FCCEDM=/afs/cern.ch/exp/fcc/sw/0.5/fcc-edm/0.1/x86_64-slc6-gcc49-opt/
 export ALBERS=/afs/cern.ch/exp/fcc/sw/0.5/albers-core/0.1/x86_64-slc6-gcc49-opt
-export DELPHES_DIR=/afs/cern.ch/exp/fcc/sw/0.5/Delphes-3.3.1/x86_64-slc6-gcc49-opt
+export DELPHES_DIR=/afs/cern.ch/exp/fcc/sw/0.5/Delphes-3.3.1-newPCMs/x86_64-slc6-gcc49-opt
 export PYTHIA_DIR=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-opt/
 
 export CMAKE_PREFIX_PATH=$FCCEDM:$ALBERS:$DELPHES_DIR:$CMAKE_PREFIX_PATH:$PYTHIA_DIR


### PR DESCRIPTION
Some example configs were missing the vertex output for the `HepMCConverter` which was re-added. Also updating the README according to Clement's comments in PR #44.

@clementhelsens can you let me know if this fixes the issues you were seeing? Thanks!

PS: Sorry for the white-space strips. 