### PR TITLE
Fix of DD4hep detector xml files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,3 @@ gaudi_add_test(ExampleOptions
 gaudi_add_test(PythiaDelphes
                 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                FRAMEWORK config/PythiaDelphes_config.py)
-gaudi_add_test(FCChhDD4hep
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-               FRAMEWORK config/FCChh_DD4HEPgui.py)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,6 @@ gaudi_add_test(GeantFullSimGdml
 gaudi_add_test(GeantFastSimTracker
                 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                FRAMEWORK config/geant_fastsim.py)
-gaudi_add_test(RecoGeo
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-               FRAMEWORK config/recogeo_options.py)
 gaudi_add_test(SimplePythia
                 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                FRAMEWORK config/simple_pythia.py)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,3 +19,35 @@ include_directories(
                      ${DELPHES_EXTERNALS_INCLUDE_DIRS}  
                      ${FCCEDM_INCLUDE_DIRS}
 )  		     
+
+include(CTest)
+gaudi_add_test(GeantFullSimTracker
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK config/geant_fullsim.py)
+gaudi_add_test(GeantFullSimHCal
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK config/geant_fullsim_hcal.py)
+gaudi_add_test(GeantFullSimGdml
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK config/geant_fullsim_gdml.py)
+gaudi_add_test(GeantFastSimTracker
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK config/geant_fastsim.py)
+gaudi_add_test(RecoGeo
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK config/recogeo_options.py)
+gaudi_add_test(SimplePythia
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK config/simple_pythia.py)
+gaudi_add_test(SimpleWorkflow
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK config/simple_workflow.py)
+gaudi_add_test(ExampleOptions
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK config/example_options.py)
+gaudi_add_test(PythiaDelphes
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK config/PythiaDelphes_config.py)
+gaudi_add_test(FCChhDD4hep
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK config/FCChh_DD4HEPgui.py)

--- a/DetectorDescription/Detectors/compact/Detector.xml
+++ b/DetectorDescription/Detectors/compact/Detector.xml
@@ -187,9 +187,9 @@
 
     <detectors>
         <!--BeamTube-->
-        <detector id="0" name="BeamTube" type="BeamTube">
+        <detector id="0" name="BeamTube" type="SimpleCylinder">
             <status id="0"/>
-            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z="Tube_length" vis="violet" material="Air"/>
+            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z_offset="0*cm" dz="Tube_length" phi0="0" deltaphi="360*deg" vis="violet" material="Air"/>
         </detector>
         <!--Barrel0-->
         <detector id="1" name="Barrel0" type="Barrel" readout="B0_Readout" vis="red">

--- a/DetectorDescription/Detectors/compact/FCCTestTracker.xml
+++ b/DetectorDescription/Detectors/compact/FCCTestTracker.xml
@@ -150,9 +150,9 @@
 
     <detectors>
         <!--BeamTube-->
-        <detector id="0" name="BeamTube" type="BeamTube">
+        <detector id="0" name="BeamTube" type="SimpleCylinder">
             <status id="0"/>
-            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z="Tube_length" vis="violet" material="Air"/>
+            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z_offset="0*cm" dz="Tube_length" phi0="0" deltaphi="360*deg" vis="violet" material="Air"/>
         </detector>
         <!--Barrel0-->
         <detector id="1" name="Barrel0" type="Barrel" readout="B0_Readout" vis="red">

--- a/DetectorDescription/Detectors/compact/ParametricSimTracker.xml
+++ b/DetectorDescription/Detectors/compact/ParametricSimTracker.xml
@@ -42,9 +42,9 @@
 
     <detectors>
         <!--BeamTube-->
-        <detector id="0" name="BeamTube" type="BeamTube">
+        <detector id="0" name="BeamTube" type="SimpleCylinder">
             <status id="0"/>
-            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z="Tube_length" vis="comp1" material="Air"/>
+            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z_offset="0*cm" dz="Tube_length" phi0="0" deltaphi="360*deg" vis="comp1" material="Air"/>
         </detector>
         <!--Barrel1-->
         <detector id="1" name="ParametricSimTracker" type="ParametricSimTracker">

--- a/DetectorDescription/Detectors/compact/TestTracker.xml
+++ b/DetectorDescription/Detectors/compact/TestTracker.xml
@@ -132,9 +132,9 @@
     
     <detectors>
         <!--BeamTube-->
-        <detector id="0" name="BeamTube" type="BeamTube">
+        <detector id="0" name="BeamTube" type="SimpleCylinder">
             <status id="0"/>
-            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z="Tube_length" vis="comp1" material="Air"/>
+            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z_offset="0*cm" dz="Tube_length" phi0="0" deltaphi="360*deg" vis="comp1" material="Air"/>
         </detector>
         <!--Barrel1-->
         <detector id="1" name="Tracker0" type="Barrel" readout="TrackerReadout">

--- a/DetectorDescription/Detectors/compact/TestTracker_1comp.xml
+++ b/DetectorDescription/Detectors/compact/TestTracker_1comp.xml
@@ -129,9 +129,9 @@
     
     <detectors>
         <!--BeamTube-->
-        <detector id="0" name="BeamTube" type="BeamTube">
+        <detector id="0" name="BeamTube" type="SimpleCylinder">
             <status id="0"/>
-            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z="Tube_length" vis="comp1"/>
+            <dimensions rmin="Tube_rmin" rmax="Tube_rmax"  z_offset="0*cm" dz="Tube_length" phi0="0" deltaphi="360*deg" vis="comp1" material="Air"/>
         </detector>
         <!--Barrel1-->
         <detector id="1" name="Tracker0" type="Barrel" readout="TrackerReadout">

--- a/DetectorDescription/Detectors/compact/TestTracker_sameMat.xml
+++ b/DetectorDescription/Detectors/compact/TestTracker_sameMat.xml
@@ -133,9 +133,9 @@
     
     <detectors>
         <!--BeamTube-->
-        <detector id="0" name="BeamTube" type="BeamTube">
+        <detector id="0" name="BeamTube" type="SimpleCylinder">
             <status id="0"/>
-            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z="Tube_length" vis="comp1" material="Air"/>
+            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z_offset="0*cm" dz="Tube_length" phi0="0" deltaphi="360*deg" vis="comp1" material="Air"/>
         </detector>
         <!--Barrel1-->
         <detector id="1" name="Tracker0" type="Barrel" readout="TrackerReadout">

--- a/DetectorDescription/Detectors/compact/nested/nested_TestTracker.xml
+++ b/DetectorDescription/Detectors/compact/nested/nested_TestTracker.xml
@@ -137,9 +137,9 @@
     
     <detectors>
         <!--BeamTube-->
-        <detector id="0" name="BeamTube" type="BeamTube">
+        <detector id="0" name="BeamTube" type="SimpleCylinder">
             <status id="0"/>
-            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z="Tube_length" vis="comp1" material="Air"/>
+            <dimensions rmin="Tube_rmin" rmax="Tube_rmax" z_offset="0*cm" dz="Tube_length" phi0="0" deltaphi="360*deg" vis="comp1" material="Air"/>
         </detector>
         <!--Envelope1-->
   <!--      <detector id="10" name="Envelope1" type="DD4hep_SubdetectorAssembly">

--- a/config/example_options.py
+++ b/config/example_options.py
@@ -16,7 +16,7 @@ out = AlbersOutput("out")
 
 ApplicationMgr( TopAlg = [reader,dumper,alberswrite,out],
                 EvtSel = 'NONE',
-                EvtMax   = -1,
+                EvtMax   = 1,
                 ExtSvc = [albersevent],
 #                EventLoop = eventloopmgr,
                 OutputLevel=INFO

--- a/config/simple_workflow.py
+++ b/config/simple_workflow.py
@@ -43,7 +43,7 @@ ApplicationMgr(
               out
               ],
     EvtSel = 'NONE',
-    EvtMax   = 1000,
+    EvtMax   = 10,
     ExtSvc = [albersevent],
     #                EventLoop = eventloopmgr,
     #                OutputLevel=DEBUG


### PR DESCRIPTION
Following the removal of BeamTube constructor in PR #49 all the occurrences of the type="BeamTube" are here changed to "SimpleCylinder".
Simple integration tests are added for the main dir configuration files (can be run with 'make test')