### PR TITLE
Fix PodioOutput to demangle namespace correctly

### DIFF
--- a/Examples/src/PodioOutput.cpp
+++ b/Examples/src/PodioOutput.cpp
@@ -37,6 +37,17 @@ StatusCode PodioOutput::execute() {
       std::string name( typeid(*(i.second)).name() );
       size_t  pos = name.find_first_not_of("0123456789");
       name.erase(0,pos);
+      // demangling the namespace: due to namespace additional characters were introduced:
+      // e.g. N3fcc18TrackHit
+      // remove any number+char before the namespace:
+      pos = name.find_first_of("0123456789");
+      size_t pos1 = name.find_first_not_of("0123456789", pos);
+      name.erase(0, pos1);
+      // replace any numbers between namespace and class with "::"
+      pos = name.find_first_of("0123456789");
+      pos1 = name.find_first_not_of("0123456789", pos);
+      name.replace(pos, pos1-pos, "::");
+
       pos = name.find("Collection");
       name.erase(pos,pos+10);
       std::string classname = "vector<"+name+"Data>";


### PR DESCRIPTION
Thanks a lot to @vvolkl for spotting this. Due to the addition of namespaces, the output collections were not saved correctly because the names were not correctly demangled. 

I added a quick fix, but as the comment at the beginning of the function states, we should improve how we get the class names.