### PR TITLE
Move to mm as default length unit

### DIFF
--- a/Generation/Generation/Units.h
+++ b/Generation/Generation/Units.h
@@ -1,0 +1,32 @@
+#ifndef GENERATION_UNITS_H
+#define GENERATION_UNITS_H
+
+#include "HepMC/Units.h"
+#include "GaudiKernel/SystemOfUnits.h"
+
+// FIXME: All these should be a constexpr, but in CLHEP / HepMC they are only const
+
+namespace gen {
+/// Default EDM units for the Generation package
+namespace edmdefault {
+const HepMC::Units::LengthUnit length = HepMC::Units::MM;
+const HepMC::Units::MomentumUnit energy = HepMC::Units::GEV;
+}
+/// Default HepMC units
+namespace hepmcdefault {
+const HepMC::Units::LengthUnit length = HepMC::Units::MM;
+const HepMC::Units::MomentumUnit energy = HepMC::Units::GEV;
+}
+/// Conversion factors from EDM to HepMC
+namespace edm2hepmc {
+const double length = HepMC::Units::conversion_factor(edmdefault::length, hepmcdefault::length);
+const double energy = HepMC::Units::conversion_factor(edmdefault::energy, hepmcdefault::energy);
+}
+/// Conversion factors from HepMC to EDM
+namespace hepmc2edm {
+const double length = HepMC::Units::conversion_factor(hepmcdefault::length, edmdefault::length);
+const double energy = HepMC::Units::conversion_factor(hepmcdefault::energy, edmdefault::energy);
+}
+}
+
+#endif /*GENERATION_UNITS_H*/

--- a/Generation/options/particleGun.py
+++ b/Generation/options/particleGun.py
@@ -12,7 +12,7 @@ particlePropertySvc = Gaudi__ParticlePropertySvc("ParticlePropertySvc",
 guntool = MomentumRangeParticleGun(PdgCodes=[-211, 211, -11, -13,  13, 11 ])
 
 smeartool = FlatSmearVertex("smeartoolname")
-# FCCSW standard unit of length: [cm]
+# FCCSW standard unit of length: [mm]
 smeartool.xVertexMin = -10
 smeartool.xVertexMax = 10
 smeartool.yVertexMin = -10

--- a/Generation/src/components/HepMCConverter.cpp
+++ b/Generation/src/components/HepMCConverter.cpp
@@ -23,8 +23,8 @@ StatusCode HepMCConverter::execute() {
   fcc::MCParticleCollection* particles = new fcc::MCParticleCollection();
   fcc::GenVertexCollection* vertices = new fcc::GenVertexCollection();
 
-  // conversion of units to cm and GeV
-  double hepmc2edm_length = HepMC::Units::conversion_factor(event->length_unit(), HepMC::Units::CM);
+  // conversion of units to mm and GeV
+  double hepmc2edm_length = HepMC::Units::conversion_factor(event->length_unit(), HepMC::Units::MM);
   double hepmc2edm_energy = HepMC::Units::conversion_factor(event->momentum_unit(),HepMC::Units::GEV);
 
   // currently only final state particles converted (no EndVertex as they didn't decay)

--- a/Generation/src/components/ParticleGunAlg.cpp
+++ b/Generation/src/components/ParticleGunAlg.cpp
@@ -49,16 +49,16 @@ StatusCode ParticleGunAlg::execute() {
   StatusCode sc = StatusCode::SUCCESS ;
   Gaudi::LorentzVector theFourMomentum ;
   Gaudi::LorentzVector origin ;
-  
+
   // prepare a new HepMC event --
   // the data service (through m_hepmchandle) will be
   // responsible for deletion of the GenEvent
-  HepMC::GenEvent * theEvent = new HepMC::GenEvent( HepMC::Units::GEV, HepMC::Units::CM) ;
-  
+  HepMC::GenEvent * theEvent = new HepMC::GenEvent( HepMC::Units::GEV, HepMC::Units::MM) ;
+
   // note: pgdid is set in function generateParticle
   int thePdgId ;
   m_particleGunTool->generateParticle( theFourMomentum , origin , thePdgId );
-  
+
   // create HepMC Vertex --
   // by calling add_vertex(), the hepmc event is given ownership
   //  of the vertex
@@ -75,15 +75,15 @@ StatusCode ParticleGunAlg::execute() {
 								      theFourMomentum.E()  ) ,
 						   thePdgId ,
 						   1 ) ; // hepmc status code for final state particle
-  
+
   v -> add_particle_out( p ) ;
-    
+
   theEvent -> add_vertex( v ) ;
   theEvent -> set_signal_process_id( 0 ) ;
   theEvent -> set_signal_process_vertex( v ) ;
 
   m_vertexSmearingTool->smearVertex(theEvent);
-  
+
   m_hepmchandle.put(theEvent);
   return sc;
 }

--- a/Generation/src/components/ParticleGunAlg.cpp
+++ b/Generation/src/components/ParticleGunAlg.cpp
@@ -8,6 +8,7 @@
 
 #include "HepMC/GenEvent.h"
 
+#include "Generation/Units.h"
 //-----------------------------------------------------------------------------
 // Implementation file for class : ParticleGun
 //
@@ -53,7 +54,7 @@ StatusCode ParticleGunAlg::execute() {
   // prepare a new HepMC event --
   // the data service (through m_hepmchandle) will be
   // responsible for deletion of the GenEvent
-  HepMC::GenEvent * theEvent = new HepMC::GenEvent( HepMC::Units::GEV, HepMC::Units::MM) ;
+  HepMC::GenEvent * theEvent = new HepMC::GenEvent( gen::hepmcdefault::energy, gen::hepmcdefault::length ) ;
 
   // note: pgdid is set in function generateParticle
   int thePdgId ;

--- a/Generation/src/components/PythiaInterface.cpp
+++ b/Generation/src/components/PythiaInterface.cpp
@@ -9,6 +9,9 @@
 #include "Pythia8/Pythia.h"
 #include "Pythia8Plugins/HepMC2.h"
 
+// FCCSW
+#include "Generation/Units.h"
+
 DECLARE_COMPONENT(PythiaInterface)
 
 PythiaInterface::PythiaInterface(const std::string& name, ISvcLocator* svcLoc):
@@ -91,7 +94,7 @@ StatusCode PythiaInterface::execute() {
   } // Debug
 
   // Define HepMC event and convert Pythia event into this HepMC event type
-  auto theEvent = new HepMC::GenEvent( HepMC::Units::GEV, HepMC::Units::MM);
+  auto theEvent = new HepMC::GenEvent( gen::hepmcdefault::energy, gen::hepmcdefault::length );
   toHepMC->fill_next_event(*m_pythia, theEvent, m_iEvent);
   //theEvent-> print();
 

--- a/Sim/SimG4Common/SimG4Common/Units.h
+++ b/Sim/SimG4Common/SimG4Common/Units.h
@@ -7,7 +7,7 @@
 /** Conversion between units.
  *
  *  Contains conversions between default units used by EDM and by Geant.
- *  Default units in FCC-EDM are (as initially discussed on FCCSoftware Meeting on 14/10/15) GeV and cm.
+ *  Default units in FCC-EDM are (as initially discussed on FCCSoftware Meeting on 14/10/15) GeV and mm.
  *  Geant4 default units are MeV and mm.
  *
  *  @author Anna Zaborowska

--- a/Sim/SimG4Common/SimG4Common/Units.h
+++ b/Sim/SimG4Common/SimG4Common/Units.h
@@ -16,7 +16,7 @@
 namespace sim {
 namespace edmdefault {
 // FIXME: these should be a constexpr, but CLHEP is only const
-const double length = CLHEP::cm;
+const double length = CLHEP::mm;
 const double energy = CLHEP::GeV;
 }
 namespace edm2g4 {


### PR DESCRIPTION
I added a new header that defines the standard units for the generation package and replaced the corresponding lines in the package to use it. 

Additionally, I changed the default edm unit for the Sim package to mm instead of cm.