### PR TITLE
Fix podio output for collections with relations

### DIFF
--- a/FWCore/components/PodioOutput.cpp
+++ b/FWCore/components/PodioOutput.cpp
@@ -55,11 +55,27 @@ StatusCode PodioOutput::execute() {
       if( m_switch.isOn(i.first) ) {
         isOn = 1;
         m_datatree->Branch(i.first.c_str(), classname.c_str(), i.second->getBufferAddress());
+        auto colls = i.second->referenceCollections();
+        if (colls != nullptr){
+          int j = 0;
+          for(auto& c : (*colls)){
+            m_datatree->Branch((i.first+"#"+std::to_string(j)).c_str(), c);
+            ++j;
+          }
+        }
       }
       debug() << isOn << " Registering collection " << classname << " " << i.first.c_str() << " containing type " << name << endmsg;
     } else {
       if ( m_switch.isOn(i.first) ) {
         m_datatree->SetBranchAddress(i.first.c_str(), i.second->getBufferAddress());
+        auto colls = i.second->referenceCollections();
+        if (colls != nullptr){
+          int j = 0;
+          for(auto& c : (*colls)){
+            m_datatree->SetBranchAddress((i.first+"#"+std::to_string(j)).c_str(), &c);
+            ++j;
+          }
+        }
       }
     }
     i.second->prepareForWrite();

--- a/FWCore/components/PodioOutput.cpp
+++ b/FWCore/components/PodioOutput.cpp
@@ -21,6 +21,7 @@ StatusCode PodioOutput::initialize() {
   if (0 == m_podioDataSvc) return StatusCode::FAILURE;
 
   m_file = std::unique_ptr<TFile>(new TFile(m_filename.c_str(),"RECREATE","data file"));
+  // Both trees are written to the ROOT file and owned by it
   m_datatree  = new TTree("events","Events tree");
   m_metadatatree = new TTree("metadata", "Metadata tree");
   m_switch = KeepDropSwitch(m_outputCommands);

--- a/FWCore/components/PodioOutput.cpp
+++ b/FWCore/components/PodioOutput.cpp
@@ -21,8 +21,8 @@ StatusCode PodioOutput::initialize() {
   if (0 == m_podioDataSvc) return StatusCode::FAILURE;
 
   m_file = std::unique_ptr<TFile>(new TFile(m_filename.c_str(),"RECREATE","data file"));
-  m_datatree  = std::unique_ptr<TTree>(new TTree("events","Events tree"));
-  m_metadatatree = std::unique_ptr<TTree>(new TTree("metadata", "Metadata tree"));
+  m_datatree  = new TTree("events","Events tree");
+  m_metadatatree = new TTree("metadata", "Metadata tree");
   m_switch = KeepDropSwitch(m_outputCommands);
   return StatusCode::SUCCESS;
 }

--- a/FWCore/components/PodioOutput.cpp
+++ b/FWCore/components/PodioOutput.cpp
@@ -5,25 +5,24 @@
 DECLARE_COMPONENT(PodioOutput)
 
 PodioOutput::PodioOutput(const std::string& name, ISvcLocator* svcLoc) :
-GaudiAlgorithm(name, svcLoc),m_first(true)
+GaudiAlgorithm(name, svcLoc), m_firstEvent(true)
 {
-  declareProperty("filename", m_filename="output.root",
-                  "Name of the file to create");
-  std::vector<std::string> defaultCommands;
-  defaultCommands.push_back("keep *");
-  declareProperty("outputCommands", m_outputCommands=defaultCommands,
+  declareProperty("filename", m_filename="output.root", "Name of the file to create");
+  declareProperty("outputCommands", m_outputCommands = {"keep *"},
                   "A set of commands to declare which collections to keep or drop.");
 }
 
 StatusCode PodioOutput::initialize() {
   if (GaudiAlgorithm::initialize().isFailure())
     return StatusCode::FAILURE;
+
   // check whether we have the PodioEvtSvc active
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(evtSvc().get());
-  if (0==m_podioDataSvc) return StatusCode::FAILURE;
-  m_file = new TFile(m_filename.c_str(),"RECREATE","data file");
-  m_datatree  = new TTree("events","Events tree");
-  m_metadatatree = new TTree("metadata", "Metadata tree");
+  if (0 == m_podioDataSvc) return StatusCode::FAILURE;
+
+  m_file = std::unique_ptr<TFile>(new TFile(m_filename.c_str(),"RECREATE","data file"));
+  m_datatree  = std::unique_ptr<TTree>(new TTree("events","Events tree"));
+  m_metadatatree = std::unique_ptr<TTree>(new TTree("metadata", "Metadata tree"));
   m_switch = KeepDropSwitch(m_outputCommands);
   return StatusCode::SUCCESS;
 }
@@ -31,56 +30,59 @@ StatusCode PodioOutput::initialize() {
 StatusCode PodioOutput::execute() {
   // for now assume identical content for every event
   // register for writing
-  for (auto& i : m_podioDataSvc->getCollections()){
-    // TODO: we need the class name in a better way
-    if (m_first) {
-      std::string name( typeid(*(i.second)).name() );
-      size_t  pos = name.find_first_not_of("0123456789");
-      name.erase(0,pos);
+  for (auto& collNamePair : m_podioDataSvc->getCollections()){
+    auto collName = collNamePair.first;
+    if (m_firstEvent) {
+      // TODO: we need the class name in a better way
+      std::string className( typeid(*(collNamePair.second)).name() );
+      size_t  pos = className.find_first_not_of("0123456789");
+      className.erase(0,pos);
       // demangling the namespace: due to namespace additional characters were introduced:
       // e.g. N3fcc18TrackHit
       // remove any number+char before the namespace:
-      pos = name.find_first_of("0123456789");
-      size_t pos1 = name.find_first_not_of("0123456789", pos);
-      name.erase(0, pos1);
+      pos = className.find_first_of("0123456789");
+      size_t pos1 = className.find_first_not_of("0123456789", pos);
+      className.erase(0, pos1);
       // replace any numbers between namespace and class with "::"
-      pos = name.find_first_of("0123456789");
-      pos1 = name.find_first_not_of("0123456789", pos);
-      name.replace(pos, pos1-pos, "::");
+      pos = className.find_first_of("0123456789");
+      pos1 = className.find_first_not_of("0123456789", pos);
+      className.replace(pos, pos1-pos, "::");
 
-      pos = name.find("Collection");
-      name.erase(pos,pos+10);
-      std::string classname = "vector<"+name+"Data>";
+      pos = className.find("Collection");
+      className.erase(pos,pos+10);
+      std::string collClassName = "vector<"+className+"Data>";
       int isOn = 0;
-      if( m_switch.isOn(i.first) ) {
+      if( m_switch.isOn(collName) ) {
         isOn = 1;
-        m_datatree->Branch(i.first.c_str(), classname.c_str(), i.second->getBufferAddress());
-        auto colls = i.second->referenceCollections();
+        m_datatree->Branch(collName.c_str(), collClassName.c_str(), collNamePair.second->getBufferAddress());
+        // Create branches for collections holding relations
+        auto colls = collNamePair.second->referenceCollections();
         if (colls != nullptr){
           int j = 0;
           for(auto& c : (*colls)){
-            m_datatree->Branch((i.first+"#"+std::to_string(j)).c_str(), c);
+            m_datatree->Branch((collName+"#"+std::to_string(j)).c_str(), c);
             ++j;
           }
         }
       }
-      debug() << isOn << " Registering collection " << classname << " " << i.first.c_str() << " containing type " << name << endmsg;
+      debug() << isOn << " Registering collection " << collClassName << " " << collName.c_str() << " containing type " << className << endmsg;
     } else {
-      if ( m_switch.isOn(i.first) ) {
-        m_datatree->SetBranchAddress(i.first.c_str(), i.second->getBufferAddress());
-        auto colls = i.second->referenceCollections();
+      if ( m_switch.isOn(collName) ) {
+        // Reconnect branches and collections
+        m_datatree->SetBranchAddress(collName.c_str(), collNamePair.second->getBufferAddress());
+        auto colls = collNamePair.second->referenceCollections();
         if (colls != nullptr){
           int j = 0;
           for(auto& c : (*colls)){
-            m_datatree->SetBranchAddress((i.first+"#"+std::to_string(j)).c_str(), &c);
+            m_datatree->SetBranchAddress((collName+"#"+std::to_string(j)).c_str(), &c);
             ++j;
           }
         }
       }
     }
-    i.second->prepareForWrite();
+    collNamePair.second->prepareForWrite();
   }
-  m_first = false;
+  m_firstEvent = false;
   debug() << "Filling DataTree .." << endmsg;
   m_datatree->Fill();
   return StatusCode::SUCCESS;

--- a/FWCore/components/PodioOutput.h
+++ b/FWCore/components/PodioOutput.h
@@ -42,9 +42,9 @@ private:
   /// The actual ROOT file
   std::unique_ptr<TFile> m_file;
   /// The tree to be filled with collections
-  std::unique_ptr<TTree> m_datatree;
+  TTree* m_datatree;
   /// The tree to be filled with meta data
-  std::unique_ptr<TTree> m_metadatatree;
+  TTree* m_metadatatree;
   /// The stored collections
   std::vector<podio::CollectionBase*> m_storedCollections;
 

--- a/FWCore/components/PodioOutput.h
+++ b/FWCore/components/PodioOutput.h
@@ -19,22 +19,33 @@ class PodioOutput : public GaudiAlgorithm {
 public:
   /// Constructor.
   PodioOutput(const std::string& name, ISvcLocator* svcLoc);
-  /// Initialize.
+
+  /// Initialization of PodioOutput. Acquires the data service, creates trees and root file.
   virtual StatusCode initialize();
-  /// Execute.
+  /// Execute. For the first event creates branches for all collections known to PodioDataSvc and prepares them for
+  /// writing. For the following events it reconnects the branches with collections and prepares them for write.
   virtual StatusCode execute();
-  /// Finalize.
+  /// Finalize. Writes the meta data tree; writes file and cleans up all ROOT-pointers.
   virtual StatusCode finalize();
 
 private:
-  bool m_first;
+  /// First event or not
+  bool m_firstEvent;
+  /// Root file name the output is written to
   std::string m_filename;
+  /// Commands which output is to be kept
   std::vector<std::string> m_outputCommands;
+  /// Switch for keeping or dropping outputs
   KeepDropSwitch m_switch;
+  /// Needed for collection ID table
   PodioDataSvc* m_podioDataSvc;
-  TFile* m_file;
-  TTree* m_datatree;
-  TTree* m_metadatatree;
+  /// The actual ROOT file
+  std::unique_ptr<TFile> m_file;
+  /// The tree to be filled with collections
+  std::unique_ptr<TTree> m_datatree;
+  /// The tree to be filled with meta data
+  std::unique_ptr<TTree> m_metadatatree;
+  /// The stored collections
   std::vector<podio::CollectionBase*> m_storedCollections;
 
 };

--- a/init.sh
+++ b/init.sh
@@ -4,7 +4,7 @@ source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r4p3/InstallAre
 export VERBOSE=
 
 export FCCEDM=/afs/cern.ch/exp/fcc/sw/0.6/fcc-edm/0.2/x86_64-slc6-gcc49-opt/
-export PODIO=/afs/cern.ch/exp/fcc/sw/0.6/podio/0.1/x86_64-slc6-gcc49-opt
+export PODIO=/afs/cern.ch/exp/fcc/sw/0.6/podio/0.2/x86_64-slc6-gcc49-opt
 export DELPHES_DIR=/afs/cern.ch/exp/fcc/sw/0.6/Delphes-3.3.1/x86_64-slc6-gcc49-opt
 export PYTHIA_DIR=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-opt/
 


### PR DESCRIPTION
Hi all,

This fixes a segv we had when reading collections that have relations. Additionally, I cleaned up the code a bit and made variable names a bit more explicit. 

Note, that currently this only works when the collections are "put" before creating the relations (a corresponding fix for PODIO is already implemented but needs to be pushed to the HEP-FCC fork).

Cheers,
Joschka