### PR TITLE
Rename readout so it is recognized by SaveHits-Tool.

### DIFF
--- a/DetectorDescription/Detectors/compact/TestTracker.xml
+++ b/DetectorDescription/Detectors/compact/TestTracker.xml
@@ -120,11 +120,11 @@
             <segmentation type="CartesianGridXY" grid_size_x="0.05*mm" grid_size_y="0.05*mm"/>
             <id>system:3,layer:2,module:11,component:2,x:32:-16,y:-16</id>
         </readout>
-        <readout name="EndCapReadout">
+        <readout name="Tracker_EndCapReadout">
             <segmentation type="CartesianGridXZ" grid_size_x="0.05*mm" grid_size_z="0.05*mm"/>
             <id>system:3,layer:2,module:6,component:2,x:32:-16,z:-16</id>
         </readout>
-        <readout name="EndCapBigReadout">
+        <readout name="Tracker_EndCapBigReadout">
             <segmentation type="CartesianGridXZ" grid_size_x="0.05*mm" grid_size_z="0.05*mm"/>
             <id>system:3,layer:2,module:7,component:2,x:32:-16,z:-16</id>
         </readout>
@@ -167,7 +167,7 @@
             </layer>
         </detector>
         <!--negEndCap1-->
-        <detector id="2" name="EndCap1_1" type="Trap_EndCap" readout="EndCapReadout">
+        <detector id="2" name="EndCap1_1" type="Trap_EndCap" readout="Tracker_EndCapReadout">
             <status id="1"/>
             <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax1" dz="EndCapZ" z ="positionz1_1"/>
             <layer id="0" inner_r="EndCapRmin1" outer_r="EndCapRmax1" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">
@@ -208,7 +208,7 @@
             </layer>
             </detector>
            <!--posEndCap1-->
-           <detector id="3" name="EndCap1_2" type="Trap_EndCap" readout="EndCapReadout">
+           <detector id="3" name="EndCap1_2" type="Trap_EndCap" readout="Tracker_EndCapReadout">
                <status id="1"/>
                <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax1" dz="EndCapZ" z ="positionz1_2"/>
                <layer id="0" inner_r="EndCapRmin1" outer_r="EndCapRmax1" dz="LayerDZ" z="layerpos3" repeat="pixelcounter1_3">
@@ -280,7 +280,7 @@
             </layer>
         </detector>
         <!--nEndCap2-->
-        <detector id="5" name="EndCap2_1" type="Trap_EndCap" readout="EndCapBigReadout">
+        <detector id="5" name="EndCap2_1" type="Trap_EndCap" readout="Tracker_EndCapBigReadout">
             <status id="2"/>
             <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax2" dz="EndCapZ" z ="positionz2_1"/>
             <layer id="0" inner_r="EndCapRmin2" outer_r="EndCapRmax2" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">
@@ -351,7 +351,7 @@
             </layer>
         </detector>
         <!--posEndCap2-->
-        <detector id="6" name="EndCap2_2" type="Trap_EndCap" readout="EndCapBigReadout">
+        <detector id="6" name="EndCap2_2" type="Trap_EndCap" readout="Tracker_EndCapBigReadout">
             <status id="2"/>
             <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax2" dz="EndCapZ" z ="positionz2_2"/>
             <layer id="0" inner_r="EndCapRmin2" outer_r="EndCapRmax2" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">

--- a/DetectorDescription/Detectors/compact/TestTracker_1comp.xml
+++ b/DetectorDescription/Detectors/compact/TestTracker_1comp.xml
@@ -119,10 +119,10 @@
         <readout name="TrackerBigReadout">
             <id>system:3,layer:2,module:11,component:2</id>
         </readout>
-        <readout name="EndCapReadout">
+        <readout name="Tracker_EndCapReadout">
             <id>system:3,layer:2,module:6,component:2</id>
         </readout>
-        <readout name="EndCapBigReadout">
+        <readout name="Tracker_EndCapBigReadout">
             <id>system:3,layer:2,module:7,component:2</id>
         </readout>
     </readouts>
@@ -165,7 +165,7 @@
             </layer>
         </detector>
         <!--negEndCap1-->
-        <detector id="2" name="EndCap1_1" type="Trap_EndCap" readout="EndCapReadout">
+        <detector id="2" name="EndCap1_1" type="Trap_EndCap" readout="Tracker_EndCapReadout">
             <status id="1"/>
             <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax1" dz="EndCapZ" z ="positionz1_1"/>
             <layer id="0" inner_r="EndCapRmin1" outer_r="EndCapRmax1" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">
@@ -206,7 +206,7 @@
             </layer>
             </detector>
            <!--posEndCap1-->
-           <detector id="3" name="EndCap1_2" type="Trap_EndCap" readout="EndCapReadout">
+           <detector id="3" name="EndCap1_2" type="Trap_EndCap" readout="Tracker_EndCapReadout">
                <status id="1"/>
                <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax1" dz="EndCapZ" z ="positionz1_2"/>
                <layer id="0" inner_r="EndCapRmin1" outer_r="EndCapRmax1" dz="LayerDZ" z="layerpos3" repeat="pixelcounter1_3">
@@ -278,7 +278,7 @@
             </layer>
         </detector>
         <!--nEndCap2-->
-        <detector id="5" name="EndCap2_1" type="Trap_EndCap" readout="EndCapBigReadout">
+        <detector id="5" name="EndCap2_1" type="Trap_EndCap" readout="Tracker_EndCapBigReadout">
             <status id="2"/>
             <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax2" dz="EndCapZ" z ="positionz2_1"/>
             <layer id="0" inner_r="EndCapRmin2" outer_r="EndCapRmax2" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">
@@ -349,7 +349,7 @@
             </layer>
         </detector>
         <!--posEndCap2-->
-        <detector id="6" name="EndCap2_2" type="Trap_EndCap" readout="EndCapBigReadout">
+        <detector id="6" name="EndCap2_2" type="Trap_EndCap" readout="Tracker_EndCapBigReadout">
             <status id="2"/>
             <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax2" dz="EndCapZ" z ="positionz2_2"/>
             <layer id="0" inner_r="EndCapRmin2" outer_r="EndCapRmax2" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">

--- a/DetectorDescription/Detectors/compact/TestTracker_sameMat.xml
+++ b/DetectorDescription/Detectors/compact/TestTracker_sameMat.xml
@@ -121,11 +121,11 @@
             <segmentation type="CartesianGridXY" grid_size_x="0.05*mm" grid_size_y="0.05*mm"/>
             <id>system:3,layer:2,module:11,component:2,x:32:-16,y:-16</id>
         </readout>
-        <readout name="EndCapReadout">
+        <readout name="Tracker_EndCapReadout">
             <segmentation type="CartesianGridXZ" grid_size_x="0.05*mm" grid_size_z="0.05*mm"/>
             <id>system:3,layer:2,module:6,component:2,x:32:-16,z:-16</id>
         </readout>
-        <readout name="EndCapBigReadout">
+        <readout name="Tracker_EndCapBigReadout">
             <segmentation type="CartesianGridXZ" grid_size_x="0.05*mm" grid_size_z="0.05*mm"/>
             <id>system:3,layer:2,module:7,component:2,x:32:-16,z:-16</id>
         </readout>
@@ -163,7 +163,7 @@
             </layer>
         </detector>
         <!--negEndCap1-->
-        <detector id="2" name="EndCap1_1" type="Trap_EndCap" readout="EndCapReadout">
+        <detector id="2" name="EndCap1_1" type="Trap_EndCap" readout="Tracker_EndCapReadout">
             <status id="1"/>
             <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax1" dz="EndCapZ" z ="positionz1_1"/>
             <layer id="0" inner_r="EndCapRmin1" outer_r="EndCapRmax1" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">
@@ -192,7 +192,7 @@
             </layer>
             </detector>
            <!--posEndCap1-->
-           <detector id="3" name="EndCap1_2" type="Trap_EndCap" readout="EndCapReadout">
+           <detector id="3" name="EndCap1_2" type="Trap_EndCap" readout="Tracker_EndCapReadout">
                <status id="1"/>
                <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax1" dz="EndCapZ" z ="positionz1_2"/>
                <layer id="0" inner_r="EndCapRmin1" outer_r="EndCapRmax1" dz="LayerDZ" z="layerpos3" repeat="pixelcounter1_3">
@@ -246,7 +246,7 @@
             </layer>
         </detector> -->
         <!--nEndCap2-->
-        <detector id="5" name="EndCap2_1" type="Trap_EndCap" readout="EndCapBigReadout">
+        <detector id="5" name="EndCap2_1" type="Trap_EndCap" readout="Tracker_EndCapBigReadout">
             <status id="2"/>
             <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax2" dz="EndCapZ" z ="positionz2_1"/>
             <layer id="0" inner_r="EndCapRmin2" outer_r="EndCapRmax2" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">
@@ -293,7 +293,7 @@
             </layer>
         </detector>
         <!--posEndCap2-->
-        <detector id="6" name="EndCap2_2" type="Trap_EndCap" readout="EndCapBigReadout">
+        <detector id="6" name="EndCap2_2" type="Trap_EndCap" readout="Tracker_EndCapBigReadout">
             <status id="2"/>
             <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax2" dz="EndCapZ" z ="positionz2_2"/>
             <layer id="0" inner_r="EndCapRmin2" outer_r="EndCapRmax2" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">

--- a/DetectorDescription/Detectors/compact/nested/nested_TestTracker.xml
+++ b/DetectorDescription/Detectors/compact/nested/nested_TestTracker.xml
@@ -118,11 +118,11 @@
             <segmentation type="CartesianGridXY" grid_size_x="0.05*mm" grid_size_y="0.05*mm"/>
             <id>system:3,layer:2,module:11,component:2,x:32:-16,y:-16</id>
         </readout>
-        <readout name="EndCapReadout">
+        <readout name="Tracker_EndCapReadout">
             <segmentation type="CartesianGridXZ" grid_size_x="0.05*mm" grid_size_z="0.05*mm"/>
             <id>system:3,layer:2,module:6,component:2,x:32:-16,z:-16</id>
         </readout>
-        <readout name="EndCapBigReadout">
+        <readout name="Tracker_EndCapBigReadout">
             <segmentation type="CartesianGridXZ" grid_size_x="0.05*mm" grid_size_z="0.05*mm"/>
             <id>system:3,layer:2,module:7,component:2,x:32:-16,z:-16</id>
         </readout>

--- a/DetectorDescription/Detectors/compact/nested/nested_nEndCap1.xml
+++ b/DetectorDescription/Detectors/compact/nested/nested_nEndCap1.xml
@@ -1,5 +1,5 @@
 <!--negEndCap1-->
-<detector id="12" name="EndCap1_1" type="Trap_EndCap" readout="EndCapReadout">
+<detector id="12" name="EndCap1_1" type="Trap_EndCap" readout="Tracker_EndCapReadout">
     <status id="1"/>
     <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax1" dz="EndCapZ" z ="positionz1_1"/>
     <layer id="0" inner_r="EndCapRmin1" outer_r="EndCapRmax1" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">

--- a/DetectorDescription/Detectors/compact/nested/nested_nEndCap2.xml
+++ b/DetectorDescription/Detectors/compact/nested/nested_nEndCap2.xml
@@ -1,5 +1,5 @@
 <!--nEndCap2-->
-<detector id="22" name="EndCap2_1" type="Trap_EndCap" readout="EndCapBigReadout">
+<detector id="22" name="EndCap2_1" type="Trap_EndCap" readout="Tracker_EndCapBigReadout">
     <status id="2"/>
     <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax2" dz="EndCapZ" z ="positionz2_1"/>
     <layer id="0" inner_r="EndCapRmin2" outer_r="EndCapRmax2" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">

--- a/DetectorDescription/Detectors/compact/nested/nested_pEndCap1.xml
+++ b/DetectorDescription/Detectors/compact/nested/nested_pEndCap1.xml
@@ -1,5 +1,5 @@
 <!--posEndCap1-->
-<detector id="13" name="EndCap1_2" type="Trap_EndCap" readout="EndCapReadout">
+<detector id="13" name="EndCap1_2" type="Trap_EndCap" readout="Tracker_EndCapReadout">
     <status id="1"/>
     <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax1" dz="EndCapZ" z ="positionz1_2"/>
     <layer id="0" inner_r="EndCapRmin1" outer_r="EndCapRmax1" dz="LayerDZ" z="layerpos3" repeat="pixelcounter1_3">

--- a/DetectorDescription/Detectors/compact/nested/nested_pEndCap2.xml
+++ b/DetectorDescription/Detectors/compact/nested/nested_pEndCap2.xml
@@ -1,5 +1,5 @@
 <!--posEndCap2-->
-<detector id="23" name="EndCap2_2" type="Trap_EndCap" readout="EndCapBigReadout">
+<detector id="23" name="EndCap2_2" type="Trap_EndCap" readout="Tracker_EndCapBigReadout">
     <status id="2"/>
     <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax2" dz="EndCapZ" z ="positionz2_2"/>
     <layer id="0" inner_r="EndCapRmin2" outer_r="EndCapRmax2" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">

--- a/DetectorDescription/Detectors/compact/nestedDetTest/TestTracker.xml
+++ b/DetectorDescription/Detectors/compact/nestedDetTest/TestTracker.xml
@@ -115,10 +115,10 @@
         <readout name="TrackerBigReadout">
             <id>system:3,layer:2,module:11,component:2</id>
         </readout>
-        <readout name="EndCapReadout">
+        <readout name="Tracker_EndCapReadout">
             <id>system:3,layer:2,module:6,component:2</id>
         </readout>
-        <readout name="EndCapBigReadout">
+        <readout name="Tracker_EndCapBigReadout">
             <id>system:3,layer:2,module:7,component:2</id>
         </readout>
     </readouts>

--- a/DetectorDescription/Detectors/compact/nestedDetTest/nEndCap1.xml
+++ b/DetectorDescription/Detectors/compact/nestedDetTest/nEndCap1.xml
@@ -1,5 +1,5 @@
 <!--negEndCap1-->
-<detector id="2" name="EndCap1_1" type="Trap_EndCap" readout="EndCapReadout">
+<detector id="2" name="EndCap1_1" type="Trap_EndCap" readout="Tracker_EndCapReadout">
     <status id="1"/>
     <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax1" dz="EndCapZ" z ="positionz1_1"/>
     <layer id="0" inner_r="EndCapRmin1" outer_r="EndCapRmax1" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">

--- a/DetectorDescription/Detectors/compact/nestedDetTest/nEndCap2.xml
+++ b/DetectorDescription/Detectors/compact/nestedDetTest/nEndCap2.xml
@@ -1,4 +1,4 @@
-<detector id="5" name="EndCap2_1" type="Trap_EndCap" readout="EndCapBigReadout">
+<detector id="5" name="EndCap2_1" type="Trap_EndCap" readout="Tracker_EndCapBigReadout">
     <status id="2"/>
     <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax2" dz="EndCapZ" z ="positionz2_1"/>
     <layer id="0" inner_r="EndCapRmin2" outer_r="EndCapRmax2" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">

--- a/DetectorDescription/Detectors/compact/nestedDetTest/pEndCap1.xml
+++ b/DetectorDescription/Detectors/compact/nestedDetTest/pEndCap1.xml
@@ -1,5 +1,5 @@
 <!--posEndCap1-->
-<detector id="3" name="EndCap1_2" type="Trap_EndCap" readout="EndCapReadout">
+<detector id="3" name="EndCap1_2" type="Trap_EndCap" readout="Tracker_EndCapReadout">
     <status id="1"/>
     <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax1" dz="EndCapZ" z ="positionz1_2"/>
     <layer id="0" inner_r="EndCapRmin1" outer_r="EndCapRmax1" dz="LayerDZ" z="layerpos3" repeat="pixelcounter1_3">

--- a/DetectorDescription/Detectors/compact/nestedDetTest/pEndCap2.xml
+++ b/DetectorDescription/Detectors/compact/nestedDetTest/pEndCap2.xml
@@ -1,5 +1,5 @@
 <!--posEndCap2-->
-<detector id="6" name="EndCap2_2" type="Trap_EndCap" readout="EndCapBigReadout">
+<detector id="6" name="EndCap2_2" type="Trap_EndCap" readout="Tracker_EndCapBigReadout">
     <status id="2"/>
     <dimensions rmin="Tracker_rmin1" rmax = "Tracker_rmax2" dz="EndCapZ" z ="positionz2_2"/>
     <layer id="0" inner_r="EndCapRmin2" outer_r="EndCapRmax2" dz="LayerDZ" z="layerpos1" repeat="pixelcounter1_3">


### PR DESCRIPTION
The current implementation of the tracker endcaps does not result in saved hits when running the simulation examples. It should conform with the conventions documented [here](https://github.com/vvolkl/FCCSW/blob/tracker_readout_fix/Sim/doc/Geant4fullsim.md#note).  As a fix, I just rename the readout.