### PR TITLE
Add easy way to compile against dbg libraries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # Generic Makefile to simplify the use of CMake projects
-# ------------------------------------------------------ 
+# ------------------------------------------------------
 #
 # This simple Makefile is meant to provide a simplified entry point for the
 # configuration and build of CMake-based projects that use a default toolchain
@@ -14,7 +14,7 @@
 #
 #     all
 #         (default) build everything
-#  
+#
 #     test [*]_
 #         run the declared tests
 #
@@ -39,11 +39,12 @@
 #
 # :Author: Marco Clemencic
 #
-# .. [*] Targets defined by this Makefile. 
+# .. [*] Targets defined by this Makefile.
 #
 ################################################################################
 
 # settings
+
 CMAKE = cmake
 ifneq ($(wildcard $(CURDIR)/toolchain.cmake),)
   override CMAKEFLAGS += -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/toolchain.cmake
@@ -52,11 +53,19 @@ endif
 ifndef BINARY_TAG
   ifdef CMAKECONFIG
     BINARY_TAG=${CMAKECONFIG}
-  else 
+  else
     ifdef CMTCONFIG
       BINARY_TAG=${CMTCONFIG}
     endif
   endif
+endif
+
+# Check if we are building against dbg libs and add flag
+$(info $(BINARY_TAG))
+DEBUG = $(findstring dbg, $(BINARY_TAG))
+
+ifeq ($(DEBUG),dbg)
+  override CMAKEFLAGS += -DCMAKE_BUILD_TYPE=Debug
 endif
 
 BUILDDIR := $(CURDIR)/build.$(BINARY_TAG)
@@ -86,7 +95,7 @@ endif
 	@ # do not delegate further
 
 # This wrapping around the test target is used to ensure the generation of
-# the XML output from ctest. 
+# the XML output from ctest.
 test: $(BUILDDIR)/Makefile
 	$(MAKE) -C build.$(BINARY_TAG) ARGS="-T test $(ARGS)" $@
 

--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,7 @@ ifndef BINARY_TAG
   endif
 endif
 
-# Check if we are building against dbg libs and add flag
-$(info $(BINARY_TAG))
-DEBUG = $(findstring dbg, $(BINARY_TAG))
-
-ifeq ($(DEBUG),dbg)
-  override CMAKEFLAGS += -DCMAKE_BUILD_TYPE=Debug
-endif
-
+override CMAKEFLAGS += -DCMAKE_BUILD_TYPE=$(BUILDTYPE)
 BUILDDIR := $(CURDIR)/build.$(BINARY_TAG)
 
 

--- a/init.sh
+++ b/init.sh
@@ -1,29 +1,34 @@
 #!/bin/sh -u
 if [ -z "$BUILDTYPE" ]; then
-    export BUILDTYPE=opt
+    export BUILD=opt
+    export BUILDTYPE=Release
+elif [ "$BUILDTYPE" == "Release" ]; then
+    export BUILD=opt
+else
+    export BUILD=dbg
 fi
 
-source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r5p7/InstallArea/scripts/LbLogin.sh --cmtconfig x86_64-slc6-gcc49-$BUILDTYPE
+source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r5p7/InstallArea/scripts/LbLogin.sh --cmtconfig x86_64-slc6-gcc49-$BUILD
 # The LbLogin sets VERBOSE to 1 which increases the compilation output. If you want details et this to 1 by hand.
 export VERBOSE=
 
 # source /afs/cern.ch/sw/lcg/views/LCG_83/x86_64-slc6-gcc49-opt/setup.sh
 
-export FCCEDM=/afs/cern.ch/exp/fcc/sw/0.7/fcc-edm/0.3/x86_64-slc6-gcc49-$BUILDTYPE/
-export PODIO=/afs/cern.ch/exp/fcc/sw/0.7/podio/0.3/x86_64-slc6-gcc49-$BUILDTYPE
+export FCCEDM=/afs/cern.ch/exp/fcc/sw/0.7/fcc-edm/0.3/x86_64-slc6-gcc49-$BUILD/
+export PODIO=/afs/cern.ch/exp/fcc/sw/0.7/podio/0.3/x86_64-slc6-gcc49-$BUILD
 export DELPHES_DIR=/afs/cern.ch/exp/fcc/sw/0.7/Delphes/3.3.2/x86_64-slc6-gcc49-opt
-export PYTHIA_DIR=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-$BUILDTYPE/
+export PYTHIA_DIR=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-$BUILD/
 
 export CMAKE_PREFIX_PATH=$FCCEDM:$PODIO:$DELPHES_DIR:/afs/cern.ch/sw/lcg/releases/LCG_83:$CMAKE_PREFIX_PATH:$PYTHIA_DIR
 
 # set up Pythia8 Index.xml
-export PYTHIA8_XML=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-$BUILDTYPE/share/Pythia8/xmldoc
+export PYTHIA8_XML=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-$BUILD/share/Pythia8/xmldoc
 
 
 
 # add DD4hep
 export inithere=$PWD
-cd /afs/cern.ch/exp/fcc/sw/0.7/DD4hep/20152311/x86_64-slc6-gcc49-$BUILDTYPE
+cd /afs/cern.ch/exp/fcc/sw/0.7/DD4hep/20152311/x86_64-slc6-gcc49-$BUILD
 source bin/thisdd4hep.sh
 cd $inithere
 

--- a/init.sh
+++ b/init.sh
@@ -1,8 +1,10 @@
 #!/bin/sh -u
 if [ -z "$BUILDTYPE" ] || [ "$BUILDTYPE" == "Release" ]; then
     export BINARY_TAG=x86_64-slc6-gcc49-opt
+    export BUILDTYPE="Release"
 else
     export BINARY_TAG=x86_64-slc6-gcc49-dbg
+    export BUILDTYPE="Debug"
 fi
 
 source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r5p7/InstallArea/scripts/LbLogin.sh --cmtconfig $BINARY_TAG

--- a/init.sh
+++ b/init.sh
@@ -1,25 +1,29 @@
 #!/bin/sh -u
-source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r5p7/InstallArea/scripts/LbLogin.sh --cmtconfig x86_64-slc6-gcc49-opt
+if [ -z "$BUILDTYPE" ]; then
+    export BUILDTYPE=opt
+fi
+
+source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r5p7/InstallArea/scripts/LbLogin.sh --cmtconfig x86_64-slc6-gcc49-$BUILDTYPE
 # The LbLogin sets VERBOSE to 1 which increases the compilation output. If you want details et this to 1 by hand.
 export VERBOSE=
 
 # source /afs/cern.ch/sw/lcg/views/LCG_83/x86_64-slc6-gcc49-opt/setup.sh
 
-export FCCEDM=/afs/cern.ch/exp/fcc/sw/0.7/fcc-edm/0.3/x86_64-slc6-gcc49-opt/
-export PODIO=/afs/cern.ch/exp/fcc/sw/0.7/podio/0.3/x86_64-slc6-gcc49-opt
+export FCCEDM=/afs/cern.ch/exp/fcc/sw/0.7/fcc-edm/0.3/x86_64-slc6-gcc49-$BUILDTYPE/
+export PODIO=/afs/cern.ch/exp/fcc/sw/0.7/podio/0.3/x86_64-slc6-gcc49-$BUILDTYPE
 export DELPHES_DIR=/afs/cern.ch/exp/fcc/sw/0.7/Delphes/3.3.2/x86_64-slc6-gcc49-opt
-export PYTHIA_DIR=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-opt/
+export PYTHIA_DIR=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-$BUILDTYPE/
 
 export CMAKE_PREFIX_PATH=$FCCEDM:$PODIO:$DELPHES_DIR:/afs/cern.ch/sw/lcg/releases/LCG_83:$CMAKE_PREFIX_PATH:$PYTHIA_DIR
 
 # set up Pythia8 Index.xml
-export PYTHIA8_XML=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-opt/share/Pythia8/xmldoc
+export PYTHIA8_XML=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-$BUILDTYPE/share/Pythia8/xmldoc
 
 
 
 # add DD4hep
 export inithere=$PWD
-cd /afs/cern.ch/exp/fcc/sw/0.7/DD4hep/20152311/x86_64-slc6-gcc49-opt
+cd /afs/cern.ch/exp/fcc/sw/0.7/DD4hep/20152311/x86_64-slc6-gcc49-$BUILDTYPE
 source bin/thisdd4hep.sh
 cd $inithere
 

--- a/init.sh
+++ b/init.sh
@@ -13,7 +13,7 @@ export VERBOSE=
 
 export FCCEDM=/afs/cern.ch/exp/fcc/sw/0.7/fcc-edm/0.3/$BINARY_TAG/
 export PODIO=/afs/cern.ch/exp/fcc/sw/0.7/podio/0.3/$BINARY_TAG
-export DELPHES_DIR=/afs/cern.ch/exp/fcc/sw/0.7/Delphes/3.3.2/x86_64-slc6-gcc49-opt
+export DELPHES_DIR=/afs/cern.ch/exp/fcc/sw/0.7/Delphes/3.3.2/$BINARY_TAG
 export PYTHIA_DIR=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/$BINARY_TAG/
 
 export CMAKE_PREFIX_PATH=$FCCEDM:$PODIO:$DELPHES_DIR:/afs/cern.ch/sw/lcg/releases/LCG_83:$CMAKE_PREFIX_PATH:$PYTHIA_DIR

--- a/init.sh
+++ b/init.sh
@@ -1,34 +1,27 @@
 #!/bin/sh -u
-if [ -z "$BUILDTYPE" ]; then
-    export BUILD=opt
-    export BUILDTYPE=Release
-elif [ "$BUILDTYPE" == "Release" ]; then
-    export BUILD=opt
+if [ -z "$BUILDTYPE" ] || [ "$BUILDTYPE" == "Release" ]; then
+    export BINARY_TAG=x86_64-slc6-gcc49-opt
 else
-    export BUILD=dbg
+    export BINARY_TAG=x86_64-slc6-gcc49-dbg
 fi
 
-source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r5p7/InstallArea/scripts/LbLogin.sh --cmtconfig x86_64-slc6-gcc49-$BUILD
+source /afs/cern.ch/lhcb/software/releases/LBSCRIPTS/LBSCRIPTS_v8r5p7/InstallArea/scripts/LbLogin.sh --cmtconfig $BINARY_TAG
 # The LbLogin sets VERBOSE to 1 which increases the compilation output. If you want details et this to 1 by hand.
 export VERBOSE=
 
-# source /afs/cern.ch/sw/lcg/views/LCG_83/x86_64-slc6-gcc49-opt/setup.sh
-
-export FCCEDM=/afs/cern.ch/exp/fcc/sw/0.7/fcc-edm/0.3/x86_64-slc6-gcc49-$BUILD/
-export PODIO=/afs/cern.ch/exp/fcc/sw/0.7/podio/0.3/x86_64-slc6-gcc49-$BUILD
+export FCCEDM=/afs/cern.ch/exp/fcc/sw/0.7/fcc-edm/0.3/$BINARY_TAG/
+export PODIO=/afs/cern.ch/exp/fcc/sw/0.7/podio/0.3/$BINARY_TAG
 export DELPHES_DIR=/afs/cern.ch/exp/fcc/sw/0.7/Delphes/3.3.2/x86_64-slc6-gcc49-opt
-export PYTHIA_DIR=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-$BUILD/
+export PYTHIA_DIR=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/$BINARY_TAG/
 
 export CMAKE_PREFIX_PATH=$FCCEDM:$PODIO:$DELPHES_DIR:/afs/cern.ch/sw/lcg/releases/LCG_83:$CMAKE_PREFIX_PATH:$PYTHIA_DIR
 
 # set up Pythia8 Index.xml
-export PYTHIA8_XML=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/x86_64-slc6-gcc49-$BUILD/share/Pythia8/xmldoc
-
-
+export PYTHIA8_XML=/afs/cern.ch/sw/lcg/releases/LCG_80/MCGenerators/pythia8/212/$BINARY_TAG/share/Pythia8/xmldoc
 
 # add DD4hep
 export inithere=$PWD
-cd /afs/cern.ch/exp/fcc/sw/0.7/DD4hep/20152311/x86_64-slc6-gcc49-$BUILD
+cd /afs/cern.ch/exp/fcc/sw/0.7/DD4hep/20152311/$BINARY_TAG
 source bin/thisdd4hep.sh
 cd $inithere
 


### PR DESCRIPTION
- Add switch to compile against dbg libraries:
```
export BUILDTYPE=Debug
source init.sh
make
```
- Switch automatically enables debug build of FCCSW itself