### PR TITLE
Forward argument to init script, removing redundant check.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,10 +1,2 @@
 #!/bin/sh -u
-if [ -z "$BUILDTYPE" ] || [[ "$BUILDTYPE" == "Release" ]]; then
-    export BINARY_TAG=x86_64-slc6-gcc49-opt
-    export BUILDTYPE="Release"
-else
-    export BINARY_TAG=x86_64-slc6-gcc49-dbg
-    export BUILDTYPE="Debug"
-fi
-source /afs/cern.ch/exp/fcc/sw/0.7/init_fcc_stack.sh afs
-
+source /afs/cern.ch/exp/fcc/sw/0.7/init_fcc_stack.sh $1


### PR DESCRIPTION
This is needed to add nightlies built against the cvmfs installations.