### PR TITLE
Fix: Units in sim->EDM

### DIFF
--- a/FWCore/components/PodioInput.cpp
+++ b/FWCore/components/PodioInput.cpp
@@ -26,7 +26,7 @@ StatusCode PodioInput::initialize() {
   for (auto& name : m_collectionNames) {
     debug() << "Finding collection " << name << " in collection registry." << endmsg;
     if (!idTable->present(name)) {
-      error() << "Requested product " << name << "not found." << endmsg;
+      error() << "Requested product " << name << " not found." << endmsg;
       return StatusCode::FAILURE;
     }
     m_collectionIDs.push_back(idTable->collectionID(name));

--- a/Sim/SimG4Components/src/SimG4SaveCalHits.cpp
+++ b/Sim/SimG4Components/src/SimG4SaveCalHits.cpp
@@ -2,6 +2,7 @@
 
 // FCCSW
 #include "DetInterface/IGeoSvc.h"
+#include "SimG4Common/Units.h"
 
 // Geant4
 #include "G4Event.hh"
@@ -72,11 +73,11 @@ StatusCode SimG4SaveCalHits::saveOutput(const G4Event& aEvent) {
           auto edmHit = edmHits->create();
           auto& edmHitCore = edmHit.core();
           edmHitCore.cellId = hit->cellID;
-          edmHitCore.energy = hit->energyDeposit;
+          edmHitCore.energy = hit->energyDeposit * sim::g42edm::energy;
           auto position = fcc::Point();
-          position.x = hit->position.x();
-          position.y = hit->position.y();
-          position.z = hit->position.z();
+          position.x = hit->position.x() * sim::g42edm::length;
+          position.y = hit->position.y() * sim::g42edm::length;
+          position.z = hit->position.z() * sim::g42edm::length;
           auto posHit = edmPositioned->create(position, edmHitCore);
         }
       }

--- a/Sim/SimG4Components/src/SimG4SaveTrackerHits.cpp
+++ b/Sim/SimG4Components/src/SimG4SaveTrackerHits.cpp
@@ -2,6 +2,7 @@
 
 // FCCSW
 #include "DetInterface/IGeoSvc.h"
+#include "SimG4Common/Units.h"
 
 // Geant4
 #include "G4Event.hh"
@@ -72,12 +73,12 @@ StatusCode SimG4SaveTrackerHits::saveOutput(const G4Event& aEvent) {
           fcc::TrackHit edmHit = edmHits->create();
           fcc::BareHit& edmHitCore = edmHit.core();
           edmHitCore.cellId = hit->cellID;
-          edmHitCore.energy = hit->energyDeposit;
+          edmHitCore.energy = hit->energyDeposit * sim::g42edm::energy;
           edmHitCore.time = hit->truth.time;
           auto position = fcc::Point();
-          position.x = hit->position.x();
-          position.y = hit->position.y();
-          position.z = hit->position.z();
+          position.x = hit->position.x() * sim::g42edm::length;
+          position.y = hit->position.y() * sim::g42edm::length;
+          position.z = hit->position.z() * sim::g42edm::length;
           edmPositions->create(position, edmHitCore);
         }
       }


### PR DESCRIPTION
Proper handling of units of hits saved to the EDM.
Before: using simulation (geant) defaults: mm & MeV
Now: using EDM defaults: mm & GeV