### PR TITLE
Fix some overlaps in TKLayout Detector

### DIFF
--- a/Detector/DetFCChhTrackerTkLayout/src/TkLayoutBarrel_Geo.cpp
+++ b/Detector/DetFCChhTrackerTkLayout/src/TkLayoutBarrel_Geo.cpp
@@ -64,7 +64,7 @@ static DD4hep::Geometry::Ref_t createTkLayoutTrackerBarrel(DD4hep::Geometry::LCD
                                                          0.5 * xModulePropertiesOdd.attr<double>("modLength")),
                                    lcdd.material(xModuleComponentOdd.materialStr()));
       DD4hep::Geometry::Position offset(
-          0, integratedModuleComponentThickness - 0.5 * xModulePropertiesOdd.attr<double>("modThickness"), 0);
+          0, integratedModuleComponentThickness - 0.5 * xModulePropertiesOdd.attr<double>("modThickness") + 0.5 * xModuleComponentOdd.thickness(), 0);
       integratedModuleComponentThickness += xModuleComponentOdd.thickness();
 
       moduleComponentVolume.setSensitiveDetector(sensDet);

--- a/Detector/DetFCChhTrackerTkLayout/src/TkLayoutBarrel_Geo.cpp
+++ b/Detector/DetFCChhTrackerTkLayout/src/TkLayoutBarrel_Geo.cpp
@@ -67,7 +67,9 @@ static DD4hep::Geometry::Ref_t createTkLayoutTrackerBarrel(DD4hep::Geometry::LCD
           0, integratedModuleComponentThickness - 0.5 * xModulePropertiesOdd.attr<double>("modThickness") + 0.5 * xModuleComponentOdd.thickness(), 0);
       integratedModuleComponentThickness += xModuleComponentOdd.thickness();
 
-      moduleComponentVolume.setSensitiveDetector(sensDet);
+      if( xModuleComponentOdd.isSensitive() ) {
+	moduleComponentVolume.setSensitiveDetector(sensDet);
+      }
       PlacedVolume placedModuleComponentVolume = moduleVolume.placeVolume(moduleComponentVolume, offset);
       placedModuleComponentVolume.addPhysVolID("component", moduleComponentCounter);
       ++moduleComponentCounter;

--- a/Detector/DetFCChhTrackerTkLayout/src/TkLayoutEndcap_Geo.cpp
+++ b/Detector/DetFCChhTrackerTkLayout/src/TkLayoutEndcap_Geo.cpp
@@ -87,8 +87,9 @@ static DD4hep::Geometry::Ref_t createTkLayoutTrackerEndcap(DD4hep::Geometry::LCD
           DD4hep::Geometry::Position(
               0, integratedCompThickness - 0.5 * xModuleProperties.attr<double>("modThickness") + 0.5 * xComp.thickness(), 0));
       placedComponentVolume.addPhysVolID("component", componentCounter);
-
-      componentVolume.setSensitiveDetector(sensDet);
+      if( xComp.isSensitive() ){
+	componentVolume.setSensitiveDetector(sensDet);
+      }
       integratedCompThickness += xComp.thickness();
       ++componentCounter;
     }

--- a/Detector/DetFCChhTrackerTkLayout/src/TkLayoutEndcap_Geo.cpp
+++ b/Detector/DetFCChhTrackerTkLayout/src/TkLayoutEndcap_Geo.cpp
@@ -85,7 +85,7 @@ static DD4hep::Geometry::Ref_t createTkLayoutTrackerEndcap(DD4hep::Geometry::LCD
       PlacedVolume placedComponentVolume = moduleVolume.placeVolume(
           componentVolume,
           DD4hep::Geometry::Position(
-              0, integratedCompThickness - 0.5 * xModuleProperties.attr<double>("modThickness"), 0));
+              0, integratedCompThickness - 0.5 * xModuleProperties.attr<double>("modThickness") + 0.5 * xComp.thickness(), 0));
       placedComponentVolume.addPhysVolID("component", componentCounter);
 
       componentVolume.setSensitiveDetector(sensDet);


### PR DESCRIPTION
Component placement was not properly done.
The offset needs to be the centre of the component, so we need to add half the thickness of the current component. The overlaps were leading some components to be completely covered by others (depending on thicknesses), and this hits were not properly recorded. Without overlaps we can also only set only the actual sensitive material to be sensitive.
(Geant4 /geometry/test/run showed the overlaps. I tested this via the copy of the files in lcgeo, did not compile or run this in fccsw)
