### PR TITLE
Fixing ECal sensitive volume name

### DIFF
--- a/Detector/DetFCChhECalSimple/src/ECalBarrel_geo.cpp
+++ b/Detector/DetFCChhECalSimple/src/ECalBarrel_geo.cpp
@@ -89,7 +89,7 @@ static DD4hep::Geometry::Ref_t createECal (DD4hep::Geometry::LCDD& lcdd,xml_h xm
     DetElement caloLayer(active_mat+"_sensitive", i);
     DD4hep::Geometry::Tube layerShape(layer_r , layer_r+active_tck, calo_dims.dz());
     lLog << MSG::DEBUG << "ECAL senst. layers :  #" << i << " from " << layer_r << " to " <<  layer_r+active_tck << endmsg;
-    Volume layerVol(active_mat, layerShape, lcdd.material(active_mat));
+    Volume layerVol(active_mat+"_sensitive", layerShape, lcdd.material(active_mat));
     PlacedVolume placedLayer = caloVol.placeVolume(layerVol);
     placedLayer.addPhysVolID("active_layer", i);
     caloLayer.setPlacement(placedLayer);


### PR DESCRIPTION
Forgotten unique name of the sensitive layer in ECal, essential for volume counting.