### PR TITLE
Add possibility for user cmake flags, set build-type default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@
 ################################################################################
 
 # settings
-
 CMAKE = cmake
 ifneq ($(wildcard $(CURDIR)/toolchain.cmake),)
   override CMAKEFLAGS += -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/toolchain.cmake
@@ -60,7 +59,16 @@ ifndef BINARY_TAG
   endif
 endif
 
+# set build type to sensible default
+ifndef BUILDTYPE
+	BUILDTYPE=Release
+endif
+
 override CMAKEFLAGS += -DCMAKE_BUILD_TYPE=$(BUILDTYPE)
+
+# allow user options for cmake (useful for debugging)
+override CMAKEFLAGS += ${CMAKEOPTS}
+
 BUILDDIR := $(CURDIR)/build.$(BINARY_TAG)
 
 


### PR DESCRIPTION
- Add cmake flags via environment variable `CMAKEOPTS`
- Default for build-type is now explicitly set to `Release`

Updated tutorial [here](https://github.com/HEP-FCC/fcc-tutorials/pull/24)