### PR TITLE
Average material over phi in Material Scan, fix PE material description

### DIFF
--- a/Detector/DetCommon/compact/materials.xml
+++ b/Detector/DetCommon/compact/materials.xml
@@ -141,8 +141,8 @@
 
   <material name="PE">
     <D type="density" value="0.95" unit="g/cm3"/>
-    <fraction n="4" ref="H"/>
-    <fraction n="2" ref="C"/>
+    <fraction n="0.6666666" ref="H"/>
+    <fraction n="0.3333333" ref="C"/>
   </material>
 
   <material name="Kapton">

--- a/Detector/DetComponents/src/MaterialScan.h
+++ b/Detector/DetComponents/src/MaterialScan.h
@@ -1,6 +1,7 @@
 #include "DetInterface/IGeoSvc.h"
 
 #include "GaudiKernel/Service.h"
+#include "GaudiKernel/Property.h"
 #include "GaudiKernel/RndmGenerators.h"
 
 /** @class MaterialScan Detector/DetComponents/src/MaterialScan.h MaterialScan.h
@@ -22,15 +23,15 @@ public:
 
 private:
   /// name of the output file
-  std::string m_filename;
+  Gaudi::Property<std::string> m_filename{this, "filename", "", "file name to save the tree to"};
   /// Handle to the geometry service from which the detector is retrieved
   SmartIF<IGeoSvc> m_geoSvc;
   /// Step size in eta
-  double m_etaBinning;
+  Gaudi::Property<double>  m_etaBinning{this, "etaBinning", 0.05, "eta bin size"};
   /// Maximum eta until which to scan, scan is performed from -m_etaMax to +m_etaMax
-  double m_etaMax;
-  /// number of different phi values to average over 
-  double m_nPhiTrials;
+  Gaudi::Property<double> m_etaMax{this, "etaMax", 6, "maximum eta value"};
+  /// number of random, uniformly distributed phi values to average over
+  Gaudi::Property<double> m_nPhiTrials{this, "nPhiTrials", 100, "number of random, uniformly distributed phi values to average over"};
   /// Flat random number generator
   Rndm::Numbers m_flatPhiDist;
 };

--- a/Detector/DetComponents/src/MaterialScan.h
+++ b/Detector/DetComponents/src/MaterialScan.h
@@ -1,6 +1,7 @@
 #include "DetInterface/IGeoSvc.h"
 
 #include "GaudiKernel/Service.h"
+#include "GaudiKernel/RndmGenerators.h"
 
 /** @class MaterialScan Detector/DetComponents/src/MaterialScan.h MaterialScan.h
  *
@@ -28,4 +29,8 @@ private:
   double m_etaBinning;
   /// Maximum eta until which to scan, scan is performed from -m_etaMax to +m_etaMax
   double m_etaMax;
+  /// number of different phi values to average over 
+  double m_nPhiTrials;
+  /// Flat random number generator
+  Rndm::Numbers m_flatPhiDist;
 };

--- a/Examples/options/material_scan.py
+++ b/Examples/options/material_scan.py
@@ -8,7 +8,7 @@ podioevent   = FCCDataSvc("EventDataSvc")
 geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectMasterMaterial.xml'], OutputLevel = DEBUG)
 
 from Configurables import MaterialScan
-materialservice = MaterialScan("GeoDump", filename="DD4hep_material_scan.root", etaBinning=0.05, etaMax=6)
+materialservice = MaterialScan("GeoDump", filename="DD4hep_material_scan.root", etaBinning=0.05, etaMax=6, nPhiTrials=100)
 
 from Configurables import PodioOutput
 ## PODIO algorithm


### PR DESCRIPTION
Adds support for a materialscan averaged over randomly drawn values of phi for the eta-slices. Also fixes a bug in the material description, where the `fraction` and `compound ` descriptions were mixed up.
