### PR TITLE
Combinatorial seeding

### DIFF
--- a/Reconstruction/RecInterface/RecInterface/ITrackSeedingTool.h
+++ b/Reconstruction/RecInterface/RecInterface/ITrackSeedingTool.h
@@ -1,0 +1,22 @@
+#ifndef RECINTERFACE_ITRACKSEEDINGTOOL_H
+#define RECINTERFACE_ITRACKSEEDINGTOOL_H
+
+// Gaudi
+#include "GaudiKernel/IAlgTool.h"
+
+#include <map>
+
+namespace fcc {
+class TrackHitCollection;
+class PositionedTrackHitCollection;
+}
+
+
+class ITrackSeedingTool : virtual public IAlgTool {
+public:
+  DeclareInterfaceID(ITrackSeedingTool, 1, 0);
+
+  virtual std::multimap<unsigned int, unsigned int> findSeeds(const fcc::PositionedTrackHitCollection* theHits) = 0;
+};
+
+#endif /* RECINTERFACE_ITRACKSEEDINGTOOL_H */

--- a/Reconstruction/RecTracker/CMakeLists.txt
+++ b/Reconstruction/RecTracker/CMakeLists.txt
@@ -31,3 +31,8 @@ gaudi_add_test(FastDigiTest
                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 			         FRAMEWORK options/fastDigiTest.py
 			         DEPENDS Examples.GeantFullSimTrackerHits)
+
+gaudi_add_test(CombinatorialTrackSeeding
+               WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+			         FRAMEWORK options/combinatorialTrackSeedingTest.py
+			         DEPENDS Examples.GeantFullSimTrackerHits)

--- a/Reconstruction/RecTracker/CMakeLists.txt
+++ b/Reconstruction/RecTracker/CMakeLists.txt
@@ -11,18 +11,19 @@ find_package(PODIO)
 find_package(HepMC)
 find_package(DD4hep COMPONENTS DDG4 DDSegmentation DDRec REQUIRED)
 find_package(ROOT)
+find_package(ACTS COMPONENTS Core Examples TGeoPlugin DD4hepPlugin)
 
 
 gaudi_install_headers(RecTracker)
 gaudi_add_library(TrackingUtils
                  src/lib/*.cpp
                  INCLUDE_DIRS ROOT FWCore HepMC FCCEDM PODIO DD4hep DetInterface RecInterface
-                 LINK_LIBRARIES ROOT GaudiAlgLib FCCEDM PODIO HepMC DD4hep ${DD4hep_COMPONENT_LIBRARIES}
+                 LINK_LIBRARIES ROOT GaudiAlgLib FCCEDM PODIO HepMC DD4hep ${DD4hep_COMPONENT_LIBRARIES} 
                  PUBLIC_HEADERS RecTracker) 
 gaudi_add_module(RecTracker
                  src/components/*.cpp
-                 INCLUDE_DIRS ROOT FWCore HepMC FCCEDM PODIO DD4hep DetInterface RecInterface TrackingUtils
-                 LINK_LIBRARIES ROOT GaudiAlgLib FCCEDM PODIO HepMC DD4hep TrackingUtils ${DD4hep_COMPONENT_LIBRARIES}) 
+                 INCLUDE_DIRS ROOT FWCore HepMC FCCEDM PODIO DD4hep DetInterface RecInterface TrackingUtils ACTS
+                 LINK_LIBRARIES ROOT GaudiAlgLib FCCEDM PODIO HepMC DD4hep TrackingUtils ${DD4hep_COMPONENT_LIBRARIES} ACTS::ACTSCore ACTS::ACTSDD4hepPlugin)
 
 include(CTest)
 

--- a/Reconstruction/RecTracker/options/combinatorialTrackSeedingTest.py
+++ b/Reconstruction/RecTracker/options/combinatorialTrackSeedingTest.py
@@ -1,0 +1,78 @@
+import os
+from GaudiKernel import SystemOfUnits as units
+from GaudiKernel import PhysicalConstants as constants
+from Gaudi.Configuration import *
+
+from Configurables import FCCDataSvc
+podioevent   = FCCDataSvc("EventDataSvc")
+from Configurables import PodioInput
+
+from Configurables import GenAlg, MomentumRangeParticleGun, PoissonPileUp 
+pileuptool = PoissonPileUp("PileUp", numPileUpEvents=12)
+pgun_tool = MomentumRangeParticleGun(PdgCodes=[13], PhiMin=0., PhiMax=constants.pi*0.5, ThetaMin=constants.pi / 2., ThetaMax=constants.pi*0.9, MomentumMin=10000, MomentumMax=100000)
+pgun_tool2 = MomentumRangeParticleGun(PdgCodes=[13], PhiMin=0., PhiMax=constants.pi*0.5, ThetaMin=constants.pi / 2., ThetaMax=constants.pi*0.9, MomentumMin=10000, MomentumMax=100000)
+gen = GenAlg("ParticleGun", SignalProvider=pgun_tool, PileUpProvider=pgun_tool2, PileUpTool=pileuptool)
+gen.hepmc.Path = "hepmc"
+
+from Configurables import Gaudi__ParticlePropertySvc
+ppservice = Gaudi__ParticlePropertySvc("ParticlePropertySvc", ParticlePropertiesFile="Generation/data/ParticleTable.txt")
+
+from Configurables import GeoSvc
+geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+  'file:Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml',
+  ],
+  )
+
+from Configurables import HepMCToEDMConverter
+hepmc_converter = HepMCToEDMConverter("Converter")
+hepmc_converter.hepmc.Path="hepmc"
+hepmc_converter.genparticles.Path="allGenParticles"
+hepmc_converter.genvertices.Path="allGenVertices"
+
+from Configurables import SimG4Svc
+geantservice = SimG4Svc("SimG4Svc", detector='SimG4DD4hepDetector', physicslist="SimG4FtfpBert", actions="SimG4FullSimActions")
+
+from Configurables import SimG4ConstantMagneticFieldTool
+field = SimG4ConstantMagneticFieldTool("SimG4ConstantMagneticFieldTool", FieldOn=True, IntegratorStepper="ClassicalRK4")
+
+from Configurables import SimG4Alg, SimG4SaveTrackerHits, SimG4PrimariesFromEdmTool
+savetrackertool = SimG4SaveTrackerHits("saveTrackerHits", readoutNames = ["TrackerBarrelReadout"])
+savetrackertool.positionedTrackHits.Path = "positionedHits"
+savetrackertool.trackHits.Path = "hits"
+particle_converter = SimG4PrimariesFromEdmTool("EdmConverter")
+particle_converter.genParticles.Path = "allGenParticles"
+geantsim = SimG4Alg("SimG4Alg",
+                    outputs = ["SimG4SaveTrackerHits/saveTrackerHits"],
+                    eventProvider=particle_converter)
+
+
+
+from Configurables import CombinatorialSeedingTest, CombinatorialSeedingTool
+
+seed_tool = CombinatorialSeedingTool()
+seed_tool.seedingLayerIndices0=(0,0)
+seed_tool.seedingLayerIndices1=(0,1)
+seed_tool.seedingLayerIndices2=(0,2)
+seed_tool.trackSeeds.Path = "trackSeeds"
+seed_tool.readoutName = "TrackerBarrelReadout"
+
+combi_seeding = CombinatorialSeedingTest()
+combi_seeding.TrackSeedingTool = seed_tool
+combi_seeding.positionedTrackHits.Path = "positionedHits"
+
+
+# PODIO algorithm
+from Configurables import PodioOutput
+out = PodioOutput("out",
+                   OutputLevel=DEBUG)
+out.outputCommands = ["keep *"]
+out.filename="combiSeeding_Example.root"
+
+from Configurables import ApplicationMgr
+ApplicationMgr( TopAlg = [gen, hepmc_converter, geantsim, combi_seeding, out],
+                EvtSel = 'NONE',
+                EvtMax   = 2,
+                # order is important, as GeoSvc is needed by SimG4Svc
+                ExtSvc = [podioevent, geoservice, geantservice, ppservice,],
+                OutputLevel=DEBUG
+ )

--- a/Reconstruction/RecTracker/src/components/CombinatorialSeedingTest.cpp
+++ b/Reconstruction/RecTracker/src/components/CombinatorialSeedingTest.cpp
@@ -27,8 +27,6 @@ CombinatorialSeedingTest::CombinatorialSeedingTest(const std::string& name, ISvc
   declareProperty("TrackSeedingTool", m_trackSeedingTool);
 }
 
-CombinatorialSeedingTest::~CombinatorialSeedingTest() {}
-
 StatusCode CombinatorialSeedingTest::initialize() {
   info() << "initialize" << endmsg;
 
@@ -41,7 +39,8 @@ StatusCode CombinatorialSeedingTest::execute() {
   const fcc::PositionedTrackHitCollection* hits = m_positionedTrackHits.get();
   auto seedmap = m_trackSeedingTool->findSeeds(hits);
 
-  for (std::multimap<unsigned int, unsigned int>::iterator it = seedmap.begin(); it != seedmap.end(); ++it) {
+  for (auto seedIdPair: seedmap) {
+    debug() << "trackseed: " << seedIdPair.first << "\t" << seedIdPair.second << endmsg;
   }
 
   return StatusCode::SUCCESS;

--- a/Reconstruction/RecTracker/src/components/CombinatorialSeedingTest.cpp
+++ b/Reconstruction/RecTracker/src/components/CombinatorialSeedingTest.cpp
@@ -1,0 +1,53 @@
+
+#include "DetInterface/IGeoSvc.h"
+
+#include "datamodel/PositionedTrackHitCollection.h"
+#include "datamodel/TrackHitCollection.h"
+#include "datamodel/TrackHitCollection.h"
+
+#include "DD4hep/LCDD.h"
+#include "DD4hep/Volumes.h"
+#include "DDRec/API/IDDecoder.h"
+#include "DDSegmentation/BitField64.h"
+#include "DDSegmentation/CartesianGridXZ.h"
+
+#include <cmath>
+#include <random>
+
+#include "CombinatorialSeedingTest.h"
+#include "RecInterface/ITrackSeedingTool.h"
+#include "RecTracker/TrackingUtils.h"
+
+DECLARE_ALGORITHM_FACTORY(CombinatorialSeedingTest)
+
+CombinatorialSeedingTest::CombinatorialSeedingTest(const std::string& name, ISvcLocator* svcLoc)
+    : GaudiAlgorithm(name, svcLoc) {
+
+  declareProperty("positionedTrackHits", m_positionedTrackHits, "Tracker hits (Input)");
+  declareProperty("TrackSeedingTool", m_trackSeedingTool);
+}
+
+CombinatorialSeedingTest::~CombinatorialSeedingTest() {}
+
+StatusCode CombinatorialSeedingTest::initialize() {
+  info() << "initialize" << endmsg;
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode CombinatorialSeedingTest::execute() {
+
+  // get hits from event store
+  const fcc::PositionedTrackHitCollection* hits = m_positionedTrackHits.get();
+  auto seedmap = m_trackSeedingTool->findSeeds(hits);
+
+  for (std::multimap<unsigned int, unsigned int>::iterator it = seedmap.begin(); it != seedmap.end(); ++it) {
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode CombinatorialSeedingTest::finalize() {
+  StatusCode sc = GaudiAlgorithm::finalize();
+  return sc;
+}

--- a/Reconstruction/RecTracker/src/components/CombinatorialSeedingTest.h
+++ b/Reconstruction/RecTracker/src/components/CombinatorialSeedingTest.h
@@ -17,23 +17,29 @@ class TrackHitCollection;
 class PositionedTrackHitCollection;
 }
 
+
+/*** @class CombinatorialSeedingTest 
+ *
+ *  Algorithm that only calls the Combinatorial Seeding tool
+ *  for testing purposes and pints a debug statement.
+ */
 class CombinatorialSeedingTest : public GaudiAlgorithm {
 public:
   CombinatorialSeedingTest(const std::string& name, ISvcLocator* svcLoc);
 
-  ~CombinatorialSeedingTest();
+  ~CombinatorialSeedingTest() = default;
 
-  StatusCode initialize();
+  StatusCode initialize() override final;
 
-  StatusCode execute();
+  StatusCode execute() override final;
 
-  StatusCode finalize();
+  StatusCode finalize() override final;
 
 private:
-  /// Pointer to the geometry service
-
+  /// TrackHits as Input to the track seeding
   DataHandle<fcc::PositionedTrackHitCollection> m_positionedTrackHits{"positionedTrackHits", Gaudi::DataHandle::Reader,
                                                                       this};
+  /// Handle to Track Seeding Tool that does the work
   ToolHandle<ITrackSeedingTool> m_trackSeedingTool{"CombinatorialSeedingTool/CombinatorialSeedingTool", this};
 };
 

--- a/Reconstruction/RecTracker/src/components/CombinatorialSeedingTest.h
+++ b/Reconstruction/RecTracker/src/components/CombinatorialSeedingTest.h
@@ -1,0 +1,40 @@
+#ifndef RECTRACKER_COMBINATORIALSEEDINGTEST_H
+#define RECTRACKER_COMBINATORIALSEEDINGTEST_H
+
+// GAUDI
+#include "GaudiAlg/GaudiAlgorithm.h"
+#include "GaudiKernel/RndmGenerators.h"
+#include "GaudiKernel/ToolHandle.h"
+
+// FCCSW
+#include "FWCore/DataHandle.h"
+
+class IGeoSvc;
+class ITrackSeedingTool;
+
+namespace fcc {
+class TrackHitCollection;
+class PositionedTrackHitCollection;
+}
+
+class CombinatorialSeedingTest : public GaudiAlgorithm {
+public:
+  CombinatorialSeedingTest(const std::string& name, ISvcLocator* svcLoc);
+
+  ~CombinatorialSeedingTest();
+
+  StatusCode initialize();
+
+  StatusCode execute();
+
+  StatusCode finalize();
+
+private:
+  /// Pointer to the geometry service
+
+  DataHandle<fcc::PositionedTrackHitCollection> m_positionedTrackHits{"positionedTrackHits", Gaudi::DataHandle::Reader,
+                                                                      this};
+  ToolHandle<ITrackSeedingTool> m_trackSeedingTool{"CombinatorialSeedingTool/CombinatorialSeedingTool", this};
+};
+
+#endif /* RECTRACKER_COMBINATORIALSEEDINGTEST_H */

--- a/Reconstruction/RecTracker/src/components/CombinatorialSeedingTool.cpp
+++ b/Reconstruction/RecTracker/src/components/CombinatorialSeedingTool.cpp
@@ -20,7 +20,8 @@ DECLARE_TOOL_FACTORY(CombinatorialSeedingTool)
 
 CombinatorialSeedingTool::CombinatorialSeedingTool(const std::string& type, const std::string& name,
                                                    const IInterface* parent)
-    : GaudiTool(type, name, parent) {
+    : GaudiTool(type, name, parent),
+      m_geoSvc("GeoSvc", "CombinatorialSeedingTool") {
   declareInterface<ITrackSeedingTool>(this);
   declareProperty("trackSeeds", m_trackSeeds, "Track Seeds (Output)");
 }
@@ -30,7 +31,6 @@ StatusCode CombinatorialSeedingTool::initialize() {
   if (sc.isFailure()) {
     return sc;
   }
-  m_geoSvc = service("GeoSvc");
   auto lcdd = m_geoSvc->lcdd();
   auto readout = lcdd->readout(m_readoutName);
   m_decoder = readout.idSpec().decoder();

--- a/Reconstruction/RecTracker/src/components/CombinatorialSeedingTool.cpp
+++ b/Reconstruction/RecTracker/src/components/CombinatorialSeedingTool.cpp
@@ -1,0 +1,96 @@
+#include "CombinatorialSeedingTool.h"
+
+#include "DetInterface/IGeoSvc.h"
+
+#include "datamodel/PositionedTrackHitCollection.h"
+#include "datamodel/TrackHitCollection.h"
+#include "datamodel/TrackStateCollection.h"
+
+#include "DD4hep/LCDD.h"
+#include "DD4hep/Volumes.h"
+#include "DDRec/API/IDDecoder.h"
+#include "DDSegmentation/BitField64.h"
+#include "DDSegmentation/CartesianGridXZ.h"
+
+#include "ACTS/Seeding/BarrelSeedFinder.hpp"
+#include "ACTS/Seeding/SpacePoint.hpp"
+#include "ACTS/Seeding/TrackSeed.hpp"
+
+DECLARE_TOOL_FACTORY(CombinatorialSeedingTool)
+
+CombinatorialSeedingTool::CombinatorialSeedingTool(const std::string& type, const std::string& name,
+                                                   const IInterface* parent)
+    : GaudiTool(type, name, parent) {
+  declareInterface<ITrackSeedingTool>(this);
+  declareProperty("trackSeeds", m_trackSeeds, "Track Seeds (Output)");
+}
+
+StatusCode CombinatorialSeedingTool::initialize() {
+  StatusCode sc = GaudiTool::initialize();
+  if (sc.isFailure()) {
+    return sc;
+  }
+  m_geoSvc = service("GeoSvc");
+  auto lcdd = m_geoSvc->lcdd();
+  auto readout = lcdd->readout(m_readoutName);
+  m_decoder = readout.idSpec().decoder();
+  return sc;
+}
+
+void CombinatorialSeedingTool::createBarrelSpacePoints(Acts::Seeding::BarrelSpacePoints<size_t>& thePoints,
+                                                       const fcc::PositionedTrackHitCollection* theHits,
+                                                       std::pair<int, int> sIndex) {
+  size_t hitCounter = 0;
+  for (auto hit : *theHits) {
+    m_decoder->setValue(hit.core().cellId);
+    if ((*m_decoder)["system"] == sIndex.first) {
+      if ((*m_decoder)["layer"] == sIndex.second) {
+        thePoints.points.emplace_back(hit.position().x, hit.position().y, hit.position().z, hitCounter);
+      }
+    }
+    ++hitCounter;
+  }
+}
+
+std::multimap<unsigned int, unsigned int>
+CombinatorialSeedingTool::findSeeds(const fcc::PositionedTrackHitCollection* theHits) {
+
+  fcc::TrackStateCollection* trackSeedCollection = m_trackSeeds.createAndPut();
+  std::multimap<unsigned int, unsigned int> theSeeds;
+
+  Acts::Seeding::HelixSeedConfig seedFinderCfg;
+  seedFinderCfg.rangePhi1 = m_rangePhi1;
+  seedFinderCfg.rangePhi2 = m_rangePhi1;
+  seedFinderCfg.maxDeltaTheta = m_dTheta;
+  Acts::Seeding::TrackSeeds3<size_t> seeds;
+
+  Acts::Seeding::BarrelSpacePoints<size_t> pointsLayer1(10);
+  Acts::Seeding::BarrelSpacePoints<size_t> pointsLayer2(20);
+  Acts::Seeding::BarrelSpacePoints<size_t> pointsLayer3(30);
+
+  createBarrelSpacePoints(pointsLayer1, theHits, m_seedingLayerIndices0);
+  createBarrelSpacePoints(pointsLayer2, theHits, m_seedingLayerIndices1);
+  createBarrelSpacePoints(pointsLayer3, theHits, m_seedingLayerIndices2);
+
+  findHelixSeeds(seedFinderCfg, pointsLayer1, pointsLayer2, pointsLayer3, seeds);
+
+  debug() << "found " << seeds.size() << " track seeds" << endmsg;
+
+  unsigned int trackCounter = 0;
+  for (const auto& seed : seeds) {
+    std::array<float, 15> edmCov;
+    float l_phi = seed.phi();
+    float l_theta = seed.theta();
+    float l_curvature = seed.curvature();
+    trackSeedCollection->create(l_phi, l_theta, l_curvature, 0.f, 0.f, fcc::Point(), edmCov);
+    for (const auto& id : seed.identifiers()) {
+      theSeeds.insert(std::pair<unsigned int, unsigned int>(trackCounter, id));
+    }
+
+    ++trackCounter;
+  }
+
+  return theSeeds;
+}
+
+StatusCode CombinatorialSeedingTool::finalize() { return GaudiTool::finalize(); }

--- a/Reconstruction/RecTracker/src/components/CombinatorialSeedingTool.h
+++ b/Reconstruction/RecTracker/src/components/CombinatorialSeedingTool.h
@@ -27,23 +27,31 @@ class CombinatorialSeedingTool : public GaudiTool, virtual public ITrackSeedingT
 public:
   CombinatorialSeedingTool(const std::string& type, const std::string& name, const IInterface* parent);
   ~CombinatorialSeedingTool() = default;
-  virtual StatusCode initialize() final;
-  virtual StatusCode finalize() final;
+  virtual StatusCode initialize() override final;
+  virtual StatusCode finalize() override final;
 
-  virtual std::multimap<unsigned int, unsigned int> findSeeds(const fcc::PositionedTrackHitCollection* theHits) final;
+  virtual std::multimap<unsigned int, unsigned int> findSeeds(const fcc::PositionedTrackHitCollection* theHits) override final;
   void createBarrelSpacePoints(Acts::Seeding::BarrelSpacePoints<size_t>& thePoints,
                                const fcc::PositionedTrackHitCollection* theHits, std::pair<int, int> sIndex);
 
 private:
-  SmartIF<IGeoSvc> m_geoSvc;
+  ServiceHandle<IGeoSvc> m_geoSvc;
   DD4hep::DDSegmentation::BitField64* m_decoder;
+  /// system and layer ids for the inner barrel layer to be used for seeding
   Gaudi::Property<std::pair<int, int>> m_seedingLayerIndices0{this, "seedingLayerIndices0", {0, 0}};
+  /// system and layer ids for the middle barrel layer to be used for seeding
   Gaudi::Property<std::pair<int, int>> m_seedingLayerIndices1{this, "seedingLayerIndices1", {0, 1}};
+  /// system and layer ids for the outer barrel layer to be used for seeding
   Gaudi::Property<std::pair<int, int>> m_seedingLayerIndices2{this, "seedingLayerIndices2", {0, 2}};
+  /// readout used for the barrel seeding layers
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "TrackerBarrelReadout"};
+  /// phi window for geometric cut on the middle layer
   Gaudi::Property<float> m_rangePhi1{this, "rangePhi1", 0.};
+  /// phi window for geometric cut on the outer layer
   Gaudi::Property<float> m_rangePhi2{this, "rangePhi2", 0.5};
+  /// theta window for geometric cut on middle and outer layer
   Gaudi::Property<float> m_dTheta{this, "maxDeltaTheta", 0.5};
+  /// output trackStates for found seeds
   DataHandle<fcc::TrackStateCollection> m_trackSeeds{"tracks/trackSeeds", Gaudi::DataHandle::Writer, this};
 };
 

--- a/Reconstruction/RecTracker/src/components/CombinatorialSeedingTool.h
+++ b/Reconstruction/RecTracker/src/components/CombinatorialSeedingTool.h
@@ -1,0 +1,50 @@
+#ifndef RECTRACKER_COMBINATORIALSEEDINGTOOL_H
+#define RECTRACKER_COMBINATORIALSEEDINGTOOL_H
+
+// from Gaudi
+#include "GaudiAlg/GaudiTool.h"
+
+// FCCSW
+#include "FWCore/DataHandle.h"
+#include "RecInterface/ITrackSeedingTool.h"
+#include "datamodel/PositionedTrackHitCollection.h"
+#include "datamodel/TrackHitCollection.h"
+#include "datamodel/TrackStateCollection.h"
+
+#include "ACTS/Seeding/SpacePoint.hpp"
+
+#include <map>
+
+class IGeoSvc;
+
+namespace DD4hep {
+namespace DDSegmentation {
+class BitField64;
+}
+}
+
+class CombinatorialSeedingTool : public GaudiTool, virtual public ITrackSeedingTool {
+public:
+  CombinatorialSeedingTool(const std::string& type, const std::string& name, const IInterface* parent);
+  ~CombinatorialSeedingTool() = default;
+  virtual StatusCode initialize() final;
+  virtual StatusCode finalize() final;
+
+  virtual std::multimap<unsigned int, unsigned int> findSeeds(const fcc::PositionedTrackHitCollection* theHits) final;
+  void createBarrelSpacePoints(Acts::Seeding::BarrelSpacePoints<size_t>& thePoints,
+                               const fcc::PositionedTrackHitCollection* theHits, std::pair<int, int> sIndex);
+
+private:
+  SmartIF<IGeoSvc> m_geoSvc;
+  DD4hep::DDSegmentation::BitField64* m_decoder;
+  Gaudi::Property<std::pair<int, int>> m_seedingLayerIndices0{this, "seedingLayerIndices0", {0, 0}};
+  Gaudi::Property<std::pair<int, int>> m_seedingLayerIndices1{this, "seedingLayerIndices1", {0, 1}};
+  Gaudi::Property<std::pair<int, int>> m_seedingLayerIndices2{this, "seedingLayerIndices2", {0, 2}};
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "TrackerBarrelReadout"};
+  Gaudi::Property<float> m_rangePhi1{this, "rangePhi1", 0.};
+  Gaudi::Property<float> m_rangePhi2{this, "rangePhi2", 0.5};
+  Gaudi::Property<float> m_dTheta{this, "maxDeltaTheta", 0.5};
+  DataHandle<fcc::TrackStateCollection> m_trackSeeds{"tracks/trackSeeds", Gaudi::DataHandle::Writer, this};
+};
+
+#endif /* RECTRACKER_COMBINATORIALSEEDINGTOOL_H */

--- a/init.sh
+++ b/init.sh
@@ -3,3 +3,6 @@
 export FCCSWBASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source /cvmfs/fcc.cern.ch/sw/0.8.1/init_fcc_stack.sh $1
 
+# TODO: temporary, until new ACTS tag available & tests work with gcc6.2
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/cvmfs/fcc.cern.ch/sw/0.8pre/acts/0.3.0/x86_64-slc6-gcc49-opt/share/cmake/ACTS/
+

--- a/init.sh
+++ b/init.sh
@@ -3,6 +3,5 @@
 export FCCSWBASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source /cvmfs/fcc.cern.ch/sw/0.8.1/init_fcc_stack.sh $1
 
-# TODO: temporary, until new ACTS tag available & tests work with gcc6.2
-export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/cvmfs/fcc.cern.ch/sw/0.8pre/acts/0.3.0/x86_64-slc6-gcc49-opt/share/cmake/ACTS/
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/cvmfs/fcc.cern.ch/sw/0.8.1/acts/0.4.0/x86_64-slc6-gcc62-opt/share/cmake/ACTS/
 


### PR DESCRIPTION
Fixes #202 .

Changes proposed in this pull-request:

- Add interface for TrackSeeding
- Integrate the Acts BarrelSeedFinder

Note that this temporarily adds the old ACTS installation to the cmake path so it can be tested. Should be substituted for ACTS 0.04.00 when available.
