### PR TITLE
Fixing segmentation violation in tests

### DIFF
--- a/Detector/DetStudies/tests/options/samplingFraction_inclinedEcal.py
+++ b/Detector/DetStudies/tests/options/samplingFraction_inclinedEcal.py
@@ -45,7 +45,7 @@ hist = SamplingFractionInLayers("hists",
                                  OutputLevel = INFO)
 hist.deposits.Path="ECalPositionedHits"
 
-THistSvc().Output = ["rec DATAFILE='histSF_inclined_e50GeV_eta0_10events.root' TYP='ROOT' OPT='RECREATE'"]
+THistSvc().Output = ["rec DATAFILE='histSF_inclined_e50GeV_eta0_1events.root' TYP='ROOT' OPT='RECREATE'"]
 THistSvc().PrintAll=True
 THistSvc().AutoSave=True
 THistSvc().AutoFlush=False

--- a/FWCore/FWCore/DataHandle.h
+++ b/FWCore/FWCore/DataHandle.h
@@ -41,8 +41,8 @@ public:
 
 private:
   ServiceHandle<IDataProviderSvc> m_eds;
-  bool m_isGoodType;
-  bool m_isCollection;
+  bool m_isGoodType{false};
+  bool m_isCollection{false};
 };
 
 //---------------------------------------------------------------------------

--- a/FWCore/FWCore/PodioDataSvc.h
+++ b/FWCore/FWCore/PodioDataSvc.h
@@ -56,9 +56,9 @@ private:
   /// PODIO EventStore, used to initialise collections
   podio::EventStore m_provider;
   /// Counter of the event number
-  int m_eventNum;
+  int m_eventNum{0};
   /// Number of events in the file / to process
-  int m_eventMax;
+  int m_eventMax{-1};
 
   SmartIF<IConversionSvc> m_cnvSvc;
 

--- a/FWCore/src/PodioDataSvc.cpp
+++ b/FWCore/src/PodioDataSvc.cpp
@@ -76,7 +76,7 @@ void PodioDataSvc::setCollectionIDs(podio::CollectionIDTable* collectionIds) {
 
 /// Standard Constructor
 PodioDataSvc::PodioDataSvc(const std::string& name, ISvcLocator* svc)
-    : DataSvc(name, svc), m_eventMax(-1), m_collectionIDs(new podio::CollectionIDTable()) {}
+    : DataSvc(name, svc), m_collectionIDs(new podio::CollectionIDTable()) {}
 
 /// Standard Destructor
 PodioDataSvc::~PodioDataSvc() {}

--- a/Generation/src/components/PythiaInterface.cpp
+++ b/Generation/src/components/PythiaInterface.cpp
@@ -39,7 +39,6 @@ PythiaInterface::PythiaInterface(const std::string& type, const std::string& nam
 
   declareProperty("VertexSmearingTool", m_vertexSmearingTool);
   declarePrivateTool(m_vertexSmearingTool, "FlatSmearVertex/VertexSmearingTool");
-  declareProperty("hepmc", m_hepmchandle, "The HepMC event (output)");
 }
 
 StatusCode PythiaInterface::initialize() {

--- a/Generation/src/components/PythiaInterface.h
+++ b/Generation/src/components/PythiaInterface.h
@@ -43,8 +43,6 @@ private:
   std::unique_ptr<Pythia8::SlowJet> m_slowJet{nullptr};
   // Tool to smear vertices
   ToolHandle<IVertexSmearingTool> m_vertexSmearingTool;
-  // Output handle for HepMC event
-  DataHandle<HepMC::GenEvent> m_hepmchandle{"HepMC", Gaudi::DataHandle::Reader, this};
   // Output handle for ME/PS matching variables
   DataHandle<fcc::FloatCollection> m_handleMePsMatchingVars{"mePsMatchingVars", Gaudi::DataHandle::Writer, this};
 

--- a/Reconstruction/RecCalorimeter/tests/options/geant_fullsim_ecal_singleparticles.py
+++ b/Reconstruction/RecCalorimeter/tests/options/geant_fullsim_ecal_singleparticles.py
@@ -1,7 +1,7 @@
 # variables energy (energy in MeV!!!!), magnetic_field (0,1), num_events (number of events) to be defined before running
 energy = 50000
 magnetic_field = 0
-num_events = 10
+num_events = 1
 
 from Gaudi.Configuration import *
 

--- a/Reconstruction/RecCalorimeter/tests/options/geant_fullsim_hcal_singleparticles.py
+++ b/Reconstruction/RecCalorimeter/tests/options/geant_fullsim_hcal_singleparticles.py
@@ -1,7 +1,7 @@
 # variables energy (energy in MeV!!!!), magnetic_field (0,1), num_events (number of events) to be defined before running
 energy = 50000
 magnetic_field = 0
-num_events = 10
+num_events = 1
 
 from Gaudi.Configuration import *
 

--- a/Reconstruction/RecCalorimeter/tests/options/geant_fullsim_hcal_singleparticles.py
+++ b/Reconstruction/RecCalorimeter/tests/options/geant_fullsim_hcal_singleparticles.py
@@ -60,7 +60,7 @@ from Configurables import PodioOutput
 out = PodioOutput("out",
                    OutputLevel=DEBUG)
 out.outputCommands = ["keep *"]
-out.filename = "output_hcalSim_e"+str(int(energy/1000))+"GeV_eta036_10events.root"
+out.filename = "output_hcalSim_e"+str(int(energy/1000))+"GeV_eta036_1events.root"
 
 #CPU information
 from Configurables import AuditorSvc, ChronoAuditor

--- a/Reconstruction/RecCalorimeter/tests/options/runEcalInclinedDigitisation.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runEcalInclinedDigitisation.py
@@ -57,7 +57,7 @@ ApplicationMgr(
               out
               ],
     EvtSel = 'NONE',
-    EvtMax   = 10,
+    EvtMax   = 1,
     ExtSvc = [podioevent, geoservice],
  )
 

--- a/Reconstruction/RecCalorimeter/tests/options/runEcalReconstruction.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runEcalReconstruction.py
@@ -2,7 +2,7 @@ from Gaudi.Configuration import *
 
 from Configurables import ApplicationMgr, FCCDataSvc, PodioOutput
 
-podioevent = FCCDataSvc("EventDataSvc", input="output_ecalSim_e50GeV_10events.root")
+podioevent = FCCDataSvc("EventDataSvc", input="output_ecalSim_e50GeV_1events.root")
 
 # reads HepMC text file and write the HepMC::GenEvent to the data service
 from Configurables import PodioInput

--- a/Reconstruction/RecCalorimeter/tests/options/runEcalReconstruction.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runEcalReconstruction.py
@@ -111,6 +111,6 @@ ApplicationMgr(
               out
               ],
     EvtSel = 'NONE',
-    EvtMax = 10,
+    EvtMax = 1,
     ExtSvc = [podioevent, geoservice],
  )

--- a/Reconstruction/RecCalorimeter/tests/options/runEcalReconstructionFlatNoise.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runEcalReconstructionFlatNoise.py
@@ -88,6 +88,6 @@ ApplicationMgr(
               out
               ],
     EvtSel = 'NONE',
-    EvtMax = 10,
+    EvtMax = 1,
     ExtSvc = [podioevent, geoservice],
  )

--- a/Reconstruction/RecCalorimeter/tests/options/runEcalReconstructionFlatNoise.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runEcalReconstructionFlatNoise.py
@@ -2,7 +2,7 @@ from Gaudi.Configuration import *
 
 from Configurables import ApplicationMgr, FCCDataSvc, PodioOutput
 
-podioevent = FCCDataSvc("EventDataSvc", input = "output_ecalSim_e50GeV_10events.root")
+podioevent = FCCDataSvc("EventDataSvc", input = "output_ecalSim_e50GeV_1events.root")
 
 # reads HepMC text file and write the HepMC::GenEvent to the data service
 from Configurables import PodioInput

--- a/Reconstruction/RecCalorimeter/tests/options/runEcalReconstructionWithoutNoise.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runEcalReconstructionWithoutNoise.py
@@ -2,7 +2,7 @@ from Gaudi.Configuration import *
 
 from Configurables import ApplicationMgr, FCCDataSvc, PodioOutput
 
-podioevent = FCCDataSvc("EventDataSvc", input = "output_ecalSim_e50GeV_10events.root")
+podioevent = FCCDataSvc("EventDataSvc", input = "output_ecalSim_e50GeV_1events.root")
 
 # reads HepMC text file and write the HepMC::GenEvent to the data service
 from Configurables import PodioInput

--- a/Reconstruction/RecCalorimeter/tests/options/runEcalReconstructionWithoutNoise.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runEcalReconstructionWithoutNoise.py
@@ -76,7 +76,7 @@ ApplicationMgr(
               out
               ],
     EvtSel = 'NONE',
-    EvtMax = 10,
+    EvtMax = 1,
     ExtSvc = [podioevent, geoservice],
  )
 

--- a/Reconstruction/RecCalorimeter/tests/options/runHcalDigitisationFlatNoise.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runHcalDigitisationFlatNoise.py
@@ -64,7 +64,7 @@ ApplicationMgr(
               out
               ],
     EvtSel = 'NONE',
-    EvtMax   = 10,
+    EvtMax   = 1,
     ExtSvc = [podioevent, geoservice],
  )
 

--- a/Reconstruction/RecCalorimeter/tests/options/runHcalDigitisationFlatNoise.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runHcalDigitisationFlatNoise.py
@@ -2,7 +2,7 @@ from Gaudi.Configuration import *
 
 from Configurables import ApplicationMgr, FCCDataSvc, PodioOutput
 
-podioevent   = FCCDataSvc("EventDataSvc", input="output_hcalSim_e50GeV_eta036_10events.root")
+podioevent   = FCCDataSvc("EventDataSvc", input="output_hcalSim_e50GeV_eta036_1events.root")
 
 # reads HepMC text file and write the HepMC::GenEvent to the data service
 from Configurables import PodioInput

--- a/Reconstruction/RecCalorimeter/tests/options/runHcalDigitisationWithoutNoise.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runHcalDigitisationWithoutNoise.py
@@ -40,7 +40,7 @@ ApplicationMgr(
               out
               ],
     EvtSel = 'NONE',
-    EvtMax   = 10,
+    EvtMax   = 1,
     ExtSvc = [podioevent, geoservice],
  )
 

--- a/Reconstruction/RecCalorimeter/tests/options/runHcalDigitisationWithoutNoise.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runHcalDigitisationWithoutNoise.py
@@ -2,7 +2,7 @@ from Gaudi.Configuration import *
 
 from Configurables import ApplicationMgr, FCCDataSvc, PodioOutput
 
-podioevent   = FCCDataSvc("EventDataSvc", input="output_hcalSim_e50GeV_eta036_10events.root")
+podioevent   = FCCDataSvc("EventDataSvc", input="output_hcalSim_e50GeV_eta036_1events.root")
 
 # reads HepMC text file and write the HepMC::GenEvent to the data service
 from Configurables import PodioInput

--- a/Reconstruction/RecTracker/options/fastDigiTest.py
+++ b/Reconstruction/RecTracker/options/fastDigiTest.py
@@ -63,7 +63,7 @@ out.filename="fastDigi_Example.root"
 from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = [gen, hepmc_converter, geantsim, fastdigi, out],
                 EvtSel = 'NONE',
-                EvtMax   = 10,
+                EvtMax   = 1,
                 # order is important, as GeoSvc is needed by SimG4Svc
                 ExtSvc = [podioevent, geoservice, geantservice, ppservice,],
                 OutputLevel=DEBUG


### PR DESCRIPTION
Fixes #204.

Changes proposed in this pull-request:

- Initialising all member variables in `PodioDataSvc` and `DataHandle` (we seem to have different optimisation flags for 6.2 / 4.9, will investigate)
- Removed an unused `DataHandle` from the `PythiaInterface`
- Reduced number of events in the configurations used to test `RecCalorimeter` to speed up our tests

To check the changes I enabled gcc6.2 tests in Jenkins.