### PR TITLE
Fix warnings

### DIFF
--- a/Detector/DetCommon/CMakeLists.txt
+++ b/Detector/DetCommon/CMakeLists.txt
@@ -15,6 +15,8 @@ include( DD4hep )
 find_package(ROOT COMPONENTS MathCore GenVector Geom REQUIRED)
 
 gaudi_install_headers(DetCommon)
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_library(DetCommon
                  src/*.cpp
                  INCLUDE_DIRS DD4hep ROOT Geant4 DetSegmentation

--- a/Detector/DetComponents/CMakeLists.txt
+++ b/Detector/DetComponents/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(DD4hep COMPONENTS DDG4 DDSegmentation DDRec REQUIRED)
 
 find_package(Geant4)
 include(${Geant4_USE_FILE})
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_module(DetComponents
                  src/*.cpp
                  INCLUDE_DIRS GaudiKernel ROOT DD4hep Geant4 FWCore DetInterface DetExtensions DetSegmentation DetCommon

--- a/Detector/DetComponents/src/CreateVolumePositions.h
+++ b/Detector/DetComponents/src/CreateVolumePositions.h
@@ -27,15 +27,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  StatusCode initialize();
+  StatusCode initialize() override;
   /**  Execute.
    *   @return status code
    */
-  StatusCode execute();
+  StatusCode execute() override;
   /**  Finalize.
    *   @return status code
    */
-  StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Pointer to the geometry service

--- a/Detector/DetComponents/src/GeoConstruction.h
+++ b/Detector/DetComponents/src/GeoConstruction.h
@@ -31,9 +31,9 @@ public:
   virtual ~GeoConstruction();
   /// Geometry construction callback: Invoke the conversion to Geant4
   /// All volumes (including world) are deleted in ~G4PhysicalVolumeStore()
-  virtual G4VPhysicalVolume* Construct() final;
+  G4VPhysicalVolume* Construct() override final;
   /// Construct SD
-  virtual void ConstructSDandField() final;
+  void ConstructSDandField() override final;
 
 private:
   /// Reference to geometry object

--- a/Detector/DetComponents/src/GeoSvc.h
+++ b/Detector/DetComponents/src/GeoSvc.h
@@ -36,9 +36,9 @@ public:
   /// Destructor
   virtual ~GeoSvc();
   /// Initialize function
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /// Finalize function
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
   /// This function generates the DD4hep geometry
   StatusCode buildDD4HepGeo();
   /// This function generates the Geant4 geometry
@@ -49,7 +49,7 @@ public:
   // receive Geant4 Geometry
   virtual G4VUserDetectorConstruction* getGeant4Geo() override;
   /// Inform that a new incident has occurred
-  virtual void handle(const Incident& inc) final;
+  void handle(const Incident& inc) override final;
 
 private:
   /// Pointer to the incident service

--- a/Detector/DetComponents/src/MaterialScan.h
+++ b/Detector/DetComponents/src/MaterialScan.h
@@ -17,8 +17,8 @@ class MaterialScan : public Service {
 public:
   explicit MaterialScan(const std::string& name, ISvcLocator* svcLoc);
 
-  virtual StatusCode initialize();
-  virtual StatusCode finalize();
+  StatusCode initialize() override;
+  StatusCode finalize() override;
   virtual ~MaterialScan(){};
 
 private:

--- a/Detector/DetComponents/src/MergeCells.h
+++ b/Detector/DetComponents/src/MergeCells.h
@@ -37,16 +37,16 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  StatusCode execute() override final;
   /**  Finalize.
 
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
 private:
   /// Pointer to the geometry service

--- a/Detector/DetComponents/src/MergeLayers.h
+++ b/Detector/DetComponents/src/MergeLayers.h
@@ -41,16 +41,16 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  StatusCode execute() override final;
   /**  Finalize.
 
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
 private:
   /// Pointer to the geometry service

--- a/Detector/DetComponents/src/RedoSegmentation.h
+++ b/Detector/DetComponents/src/RedoSegmentation.h
@@ -45,15 +45,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  StatusCode execute() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
 private:
   /**  Get ID of the volume that contains the cell.

--- a/Detector/DetFCChhECalInclined/CMakeLists.txt
+++ b/Detector/DetFCChhECalInclined/CMakeLists.txt
@@ -15,6 +15,8 @@ include( DD4hep )
 
 find_package(ROOT COMPONENTS MathCore GenVector Geom REQUIRED)
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_module(DetFCChhECalInclined
                  src/*.cpp
                  INCLUDE_DIRS DD4hep ROOT DetExtensions Geant4

--- a/Detector/DetFCChhECalSimple/CMakeLists.txt
+++ b/Detector/DetFCChhECalSimple/CMakeLists.txt
@@ -16,6 +16,8 @@ include( DD4hep )
 
 find_package(ROOT COMPONENTS MathCore GenVector Geom REQUIRED)
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_module(DetFCChhECalSimple
                  src/*.cpp
                  INCLUDE_DIRS DD4hep ROOT DetExtensions Geant4

--- a/Detector/DetFCChhHCalTile/CMakeLists.txt
+++ b/Detector/DetFCChhHCalTile/CMakeLists.txt
@@ -16,6 +16,8 @@ include( DD4hep )
 
 find_package(ROOT COMPONENTS MathCore GenVector Geom REQUIRED)
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_module(DetFCChhHCalTile
 		  src/*.cpp
 		  INCLUDE_DIRS DD4hep ROOT DetExtensions Geant4

--- a/Detector/DetFCChhTrackerTkLayout/CMakeLists.txt
+++ b/Detector/DetFCChhTrackerTkLayout/CMakeLists.txt
@@ -16,6 +16,8 @@ include( DD4hep )
 find_package(ROOT COMPONENTS MathCore GenVector Geom REQUIRED)
 
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_module(DetFCChhTrackerTkLayout
                  src/*.cpp
                  INCLUDE_DIRS DD4hep ROOT Geant4 DetCommon 

--- a/Detector/DetSegmentation/CMakeLists.txt
+++ b/Detector/DetSegmentation/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(ROOT COMPONENTS MathCore Physics GenVector Geom REQUIRED)
 
 gaudi_install_headers(DetSegmentation)
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_library(DetSegmentation
                  src/*.cpp
                  INCLUDE_DIRS DD4hep ROOT

--- a/Detector/DetSegmentation/DetSegmentation/GridEta.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridEta.h
@@ -30,15 +30,15 @@ public:
    *   @param[in] aCellId ID of a cell.
    *   return Position (radius = 1).
    */
-  virtual Vector3D position(const CellID& aCellID) const;
+  Vector3D position(const CellID& aCellID) const override;
   /**  Determine the cell ID based on the position.
    *   @param[in] aLocalPosition (not used).
    *   @param[in] aGlobalPosition position in the global coordinates.
    *   @param[in] aVolumeId ID of a volume.
    *   return Cell ID.
    */
-  virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                        const VolumeID& aVolumeID) const;
+  CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
+                const VolumeID& aVolumeID) const override;
   /**  Determine the pseudorapidity based on the cell ID.
    *   @param[in] aCellId ID of a cell.
    *   return Pseudorapidity.

--- a/Detector/DetSegmentation/DetSegmentation/GridPhiEta.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridPhiEta.h
@@ -29,15 +29,15 @@ public:
    *   @param[in] aCellId ID of a cell.
    *   return Position (radius = 1).
    */
-  virtual Vector3D position(const CellID& aCellID) const;
+  Vector3D position(const CellID& aCellID) const override;
   /**  Determine the cell ID based on the position.
    *   @param[in] aLocalPosition (not used).
    *   @param[in] aGlobalPosition position in the global coordinates.
    *   @param[in] aVolumeId ID of a volume.
    *   return Cell ID.
    */
-  virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                        const VolumeID& aVolumeID) const;
+  CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
+                const VolumeID& aVolumeID) const override;
   /**  Determine the azimuthal angle based on the cell ID.
    *   @param[in] aCellId ID of a cell.
    *   return Phi.

--- a/Detector/DetSegmentation/DetSegmentation/GridRPhiEta.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridRPhiEta.h
@@ -28,15 +28,15 @@ public:
    *   @param[in] aCellId ID of a cell.
    *   return Position.
    */
-  virtual Vector3D position(const CellID& aCellID) const;
+  Vector3D position(const CellID& aCellID) const override;
   /**  Determine the cell ID based on the position.
    *   @param[in] aLocalPosition (not used).
    *   @param[in] aGlobalPosition position in the global coordinates.
    *   @param[in] aVolumeId ID of a volume.
    *   return Cell ID.
    */
-  virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                        const VolumeID& aVolumeID) const;
+  CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
+                const VolumeID& aVolumeID) const override;
   /**  Determine the radius based on the cell ID.
    *   @param[in] aCellId ID of a cell.
    *   return Radius.

--- a/Detector/DetSensitive/CMakeLists.txt
+++ b/Detector/DetSensitive/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(ROOT COMPONENTS MathCore GenVector Geom REQUIRED)
 
 gaudi_install_headers(DetSensitive)
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_library(DetSensitive
                   src/*.cpp
                   INCLUDE_DIRS Geant4 DD4hep ROOT DetCommon

--- a/Detector/DetSensitive/DetSensitive/AggregateCalorimeterSD.h
+++ b/Detector/DetSensitive/DetSensitive/AggregateCalorimeterSD.h
@@ -37,7 +37,7 @@ public:
    *  The hit collection is registered in Geant.
    *  @param aHitsCollections Geant hits collection.
    */
-  virtual void Initialize(G4HCofThisEvent* aHitsCollections) final;
+  void Initialize(G4HCofThisEvent* aHitsCollections) override final;
   /** Process hit once the particle hit the sensitive volume.
    *  Checks if the energy deposit is larger than 0, calculates the position and cellID,
    *  saves that into the hit collection.
@@ -45,7 +45,7 @@ public:
    *  Otherwise new hit is created.
    *  @param aStep Step in which particle deposited the energy.
    */
-  virtual bool ProcessHits(G4Step* aStep, G4TouchableHistory*) final;
+  bool ProcessHits(G4Step* aStep, G4TouchableHistory*) override final;
 
 private:
   /// Collection of calorimeter hits

--- a/Detector/DetSensitive/DetSensitive/BirksLawCalorimeterSD.h
+++ b/Detector/DetSensitive/DetSensitive/BirksLawCalorimeterSD.h
@@ -38,7 +38,7 @@ public:
    *  The hit collection is registered in Geant.
    *  @param aHitsCollections Geant hits collection.
    */
-  virtual void Initialize(G4HCofThisEvent* aHitsCollections) final;
+  void Initialize(G4HCofThisEvent* aHitsCollections) override final;
   /** Process hit once the particle hit the sensitive volume.
    *  Checks if the energy deposit is larger than 0, calculates the position and cellID,
    *  saves that into the hit collection.
@@ -49,7 +49,7 @@ public:
    *  New hit is created for each energy deposit.
    *  @param aStep Step in which particle deposited the energy.
    */
-  virtual bool ProcessHits(G4Step* aStep, G4TouchableHistory*) final;
+  bool ProcessHits(G4Step* aStep, G4TouchableHistory*) override final;
 
 private:
   /// Collection of calorimeter hits

--- a/Detector/DetSensitive/DetSensitive/GflashCalorimeterSD.h
+++ b/Detector/DetSensitive/DetSensitive/GflashCalorimeterSD.h
@@ -38,7 +38,7 @@ public:
    *  The hit collection is registered in Geant.
    *  @param aHitsCollections Geant hits collection.
    */
-  void Initialize(G4HCofThisEvent* aHCE);
+  void Initialize(G4HCofThisEvent* aHCE) override;
   /** Process hit once the particle hit the sensitive volume (anf full sim is performed)
    *  Full simulation is be invoked if the gflash model is not triggered (e.g. because of confinement)
    *  Checks if the energy deposit is larger than 0, calculates the position and cellID,
@@ -47,7 +47,7 @@ public:
    *  Otherwise new hit is created.
    *  @param aStep Step in which particle deposited the energy.
    */
-  virtual bool ProcessHits(G4Step* aStep, G4TouchableHistory*) final;
+  bool ProcessHits(G4Step* aStep, G4TouchableHistory*) override final;
   /** Process hit once the particle hit the sensitive volume and gflash parametrisation is triggered.
    *  Checks if the energy deposit is larger than 0, calculates the position and cellID,
    *  saves that into the hit collection.
@@ -55,7 +55,7 @@ public:
    *  Otherwise new hit is created.
    *  @param aSpot Spot in which particle triggered the GFlash model.
    */
-  virtual bool ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) final;
+  bool ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) override final;
   uint64_t cellID(const G4GFlashSpot& aSpot);
 
 private:

--- a/Detector/DetSensitive/DetSensitive/MiddleStepTrackerSD.h
+++ b/Detector/DetSensitive/DetSensitive/MiddleStepTrackerSD.h
@@ -34,14 +34,14 @@ public:
    *  The hit collection is registered in Geant.
    *  @param aHitsCollections Geant hits collection.
    */
-  virtual void Initialize(G4HCofThisEvent* aHitsCollections) final;
+  void Initialize(G4HCofThisEvent* aHitsCollections) override final;
   /** Process hit once the particle hit the sensitive volume.
    *  Checks if the energy deposit is larger than 0, calculates the position and cellID,
    *  saves that into the hit collection.
    *  New hit is created for each energy deposit (to save information about time)
    *  @param aStep Step in which particle deposited the energy.
    */
-  virtual bool ProcessHits(G4Step* aStep, G4TouchableHistory*) final;
+  bool ProcessHits(G4Step* aStep, G4TouchableHistory*) override final;
 
 private:
   /// Collection of tracker hits

--- a/Detector/DetSensitive/DetSensitive/SimpleCalorimeterSD.h
+++ b/Detector/DetSensitive/DetSensitive/SimpleCalorimeterSD.h
@@ -38,14 +38,14 @@ public:
    *  The hit collection is registered in Geant.
    *  @param aHitsCollections Geant hits collection.
    */
-  virtual void Initialize(G4HCofThisEvent* aHitsCollections) final;
+  void Initialize(G4HCofThisEvent* aHitsCollections) override final;
   /** Process hit once the particle hit the sensitive volume.
    *  Checks if the energy deposit is larger than 0, calculates the position and cellID,
    *  saves that into the hit collection.
    *  New hit is created for each energy deposit.
    *  @param aStep Step in which particle deposited the energy.
    */
-  virtual bool ProcessHits(G4Step* aStep, G4TouchableHistory*) final;
+  bool ProcessHits(G4Step* aStep, G4TouchableHistory*) override final;
 
 private:
   /// Collection of calorimeter hits

--- a/Detector/DetSensitive/DetSensitive/SimpleTrackerSD.h
+++ b/Detector/DetSensitive/DetSensitive/SimpleTrackerSD.h
@@ -35,14 +35,14 @@ public:
    *  The hit collection is registered in Geant.
    *  @param aHitsCollections Geant hits collection.
    */
-  virtual void Initialize(G4HCofThisEvent* aHitsCollections) final;
+  void Initialize(G4HCofThisEvent* aHitsCollections) override final;
   /** Process hit once the particle hit the sensitive volume.
    *  Checks if the energy deposit is larger than 0, calculates the position and cellID,
    *  saves that into the hit collection.
    *  New hit is created for each energy deposit (to save information about time)
    *  @param aStep Step in which particle deposited the energy.
    */
-  virtual bool ProcessHits(G4Step* aStep, G4TouchableHistory*) final;
+  bool ProcessHits(G4Step* aStep, G4TouchableHistory*) override final;
 
 private:
   /// Collection of tracker hits

--- a/Detector/DetStudies/CMakeLists.txt
+++ b/Detector/DetStudies/CMakeLists.txt
@@ -13,6 +13,8 @@ find_package(FCCEDM)
 find_package(PODIO)
 find_package(CLHEP)
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_module(DetStudies
                  src/components/*.cpp
                  INCLUDE_DIRS GaudiKernel ROOT DD4hep FWCore CLHEP

--- a/Detector/DetStudies/src/components/SamplingFractionInLayers.h
+++ b/Detector/DetStudies/src/components/SamplingFractionInLayers.h
@@ -34,15 +34,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Fills the histograms.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  StatusCode execute() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
 private:
   /// Pointer to the interface of histogram service

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -11,9 +11,11 @@ find_package(DD4hep COMPONENTS DDG4 DDSegmentation REQUIRED)
 include(DD4hep)
 find_package(Geant4)
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS} ${Geant4_INCLUDE_DIRS})
+
 gaudi_add_module(Examples
                  src/*.cpp
-		           INCLUDE_DIRS ROOT GaudiKernel Geant4 DD4hep SimG4Interface DetInterface
+                 INCLUDE_DIRS ROOT GaudiKernel Geant4 DD4hep SimG4Interface DetInterface
                  LINK_LIBRARIES GaudiAlgLib FWCore ROOT GaudiKernel DD4hep ${DD4hep_COMPONENT_LIBRARIES} Geant4)
 
 
@@ -25,12 +27,12 @@ gaudi_add_test(DummyGen
                FRAMEWORK tests/options/examplejob.py)
 gaudi_add_test(DummyGenCheck
                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Examples/tests
-			         COMMAND python ./scripts/dummy_gen_test.py
-			         DEPENDS DummyGen)
+               COMMAND python ./scripts/dummy_gen_test.py
+               DEPENDS DummyGen)
 gaudi_add_test(DummyCheck
                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Examples/tests
-			         COMMAND python ./scripts/test.py
-			         FAILS)
+               COMMAND python ./scripts/test.py
+               FAILS)
 # End of simple examples
 
 # Tests of example configs

--- a/Examples/src/CreateSampleJet.h
+++ b/Examples/src/CreateSampleJet.h
@@ -16,11 +16,11 @@ public:
   /// Constructor.
   CreateSampleJet(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Handle for the jets to be written

--- a/Examples/src/GeoToGdmlDumpSvc.h
+++ b/Examples/src/GeoToGdmlDumpSvc.h
@@ -18,9 +18,9 @@ public:
   /// Constructor.
   explicit GeoToGdmlDumpSvc(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /// Destructor
   virtual ~GeoToGdmlDumpSvc() {}
 

--- a/Examples/src/InspectHitsCollectionsTool.h
+++ b/Examples/src/InspectHitsCollectionsTool.h
@@ -22,11 +22,11 @@ public:
   explicit InspectHitsCollectionsTool(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~InspectHitsCollectionsTool();
   /// Initialize.
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /// Finalize.
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
   /// inspect output
-  virtual StatusCode saveOutput(const G4Event& aEvent) final;
+  StatusCode saveOutput(const G4Event& aEvent) override final;
 
 private:
   /// Pointer to the geometry service

--- a/Examples/src/ReadTestConsumer.cpp
+++ b/Examples/src/ReadTestConsumer.cpp
@@ -16,9 +16,9 @@ public:
 
   ~ReadTestConsumer(){};
 
-  StatusCode initialize() { return GaudiAlgorithm::initialize(); }
+  StatusCode initialize() override { return GaudiAlgorithm::initialize(); }
 
-  StatusCode execute() {
+  StatusCode execute() override {
     // Read the input
     const fcc::MCParticleCollection* mcparticles = m_genParticles.get();
 
@@ -36,7 +36,7 @@ public:
     return StatusCode::SUCCESS;
   }
 
-  StatusCode finalize() { return GaudiAlgorithm::finalize(); }
+  StatusCode finalize() override { return GaudiAlgorithm::finalize(); }
 
 private:
   /// Particles to read

--- a/FWCore/CMakeLists.txt
+++ b/FWCore/CMakeLists.txt
@@ -3,6 +3,7 @@
 ################################################################################
 gaudi_subdir(FWCore v1r0)
 
+
 find_package(FCCEDM)
 find_package(PODIO)
 find_package(ROOT COMPONENTS RIO Tree)
@@ -12,15 +13,18 @@ gaudi_depends_on_subdirs(GaudiAlg GaudiKernel)
 gaudi_install_scripts()
 gaudi_install_python_modules()
 
+include_directories(SYSTEM ${ROOT_INCLUDE_DIRS}  "$ENV{HEPMC_PREFIX}/include")
+
 gaudi_add_library(FWCore
-		  src/*.cpp
-                  LINK_LIBRARIES GaudiAlgLib GaudiKernel FCCEDM PODIO
-                  INCLUDE_DIRS FCCEDM PODIO
+                  src/*.cpp
+                  LINK_LIBRARIES GaudiAlgLib GaudiKernel FCCEDM PODIO ROOT
+                  INCLUDE_DIRS ROOT FCCEDM PODIO
                   PUBLIC_HEADERS FWCore)
 
 gaudi_add_module(FWCorePlugins
                  src/components/*.cpp
-                 LINK_LIBRARIES GaudiAlgLib GaudiKernel FWCore ROOT)
+                 LINK_LIBRARIES GaudiAlgLib GaudiKernel FWCore ROOT
+                 INCLUDE_DIRS ROOT)
 
 
 

--- a/FWCore/FWCore/DataWrapper.h
+++ b/FWCore/FWCore/DataWrapper.h
@@ -24,7 +24,7 @@ public:
   const T* getData() { return m_data; }
   void setData(T* data) { m_data = data; }
   /// try to cast to collectionBase; may return nullptr;
-  virtual podio::CollectionBase* collectionBase();
+  virtual podio::CollectionBase* collectionBase() override final;
 
 private:
   T* m_data;

--- a/FWCore/FWCore/PodioDataSvc.h
+++ b/FWCore/FWCore/PodioDataSvc.h
@@ -22,10 +22,10 @@ class PodioDataSvc : public DataSvc {
 public:
   typedef std::vector<std::pair<std::string, podio::CollectionBase*>> CollRegistry;
 
-  virtual StatusCode initialize();
-  virtual StatusCode reinitialize();
-  virtual StatusCode finalize();
-  virtual StatusCode clearStore();
+  virtual StatusCode initialize() override final;
+  virtual StatusCode reinitialize() override final;
+  virtual StatusCode finalize() override final;
+  virtual StatusCode clearStore() override final;
 
   /// Standard Constructor
   PodioDataSvc(const std::string& name, ISvcLocator* svc);
@@ -37,7 +37,7 @@ public:
   using DataSvc::registerObject;
   /// Overriding standard behaviour of evt service
   /// Register object with the data store.
-  virtual StatusCode registerObject(const std::string& fullPath, DataObject* pObject) final;
+  virtual StatusCode registerObject(const std::string& fullPath, DataObject* pObject) override final;
 
   StatusCode readCollection(const std::string& collectionName, int collectionID);
 

--- a/FWCore/src/components/PodioInput.h
+++ b/FWCore/src/components/PodioInput.h
@@ -25,11 +25,11 @@ public:
   /// Constructor.
   PodioInput(const std::string& name, ISvcLocator* svcLoc);
   /// Initialization of PodioInput. Acquires the data service, opens root file and creates trees.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute. Re-creates collections that are specified to be read and sets references.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize. Closes ROOT file.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Name of collections to read. Set by option collections (this is temporary)

--- a/FWCore/src/components/PodioOutput.h
+++ b/FWCore/src/components/PodioOutput.h
@@ -21,12 +21,12 @@ public:
   PodioOutput(const std::string& name, ISvcLocator* svcLoc);
 
   /// Initialization of PodioOutput. Acquires the data service, creates trees and root file.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute. For the first event creates branches for all collections known to PodioDataSvc and prepares them for
   /// writing. For the following events it reconnects the branches with collections and prepares them for write.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize. Writes the meta data tree; writes file and cleans up all ROOT-pointers.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   void resetBranches(const std::vector<std::pair<std::string, podio::CollectionBase*>>& collections, bool prepare);

--- a/Generation/CMakeLists.txt
+++ b/Generation/CMakeLists.txt
@@ -8,11 +8,14 @@ gaudi_depends_on_subdirs(GaudiAlg FWCore)
 
 find_package(HepMC)
 find_package(Pythia8 COMPONENTS pythia8 pythia8tohepmc)
+find_package(ROOT)
 find_package(FCCEDM)
 find_package(PODIO)
 
 gaudi_install_headers(Generation)
 gaudi_install_python_modules()
+
+include_directories(SYSTEM ${HepMC_INCLUDE_DIRS} ${PYTHIA8_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS})
 
 gaudi_add_module(Generation
                  src/components/*.cpp

--- a/Generation/src/components/ConstPileUp.h
+++ b/Generation/src/components/ConstPileUp.h
@@ -23,18 +23,18 @@ public:
   virtual ~ConstPileUp();  ///< Destructor
 
   /// Initialize method
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
 
   /** Implements IPileUpTool::numberOfPileUp.
    */
-  virtual unsigned int numberOfPileUp();
+  unsigned int numberOfPileUp() override;
 
-  virtual double getMeanPileUp();
+  double getMeanPileUp() override;
   /** Implements IPileUpTool::printPileUpCounters.
    */
-  virtual void printPileUpCounters();
+  void printPileUpCounters() override;
 
-  virtual std::string getFilename();
+  std::string getFilename() override;
 
 private:
   /// Number of min bias events to pile on signal event.

--- a/Generation/src/components/EDMToHepMCConverter.h
+++ b/Generation/src/components/EDMToHepMCConverter.h
@@ -18,11 +18,11 @@ public:
   /// Constructor.
   EDMToHepMCConverter(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Handle for the HepMC to be read

--- a/Generation/src/components/FlatSmearVertex.h
+++ b/Generation/src/components/FlatSmearVertex.h
@@ -24,11 +24,11 @@ public:
   virtual ~FlatSmearVertex();  ///< Destructor
 
   /// Initialize method
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
 
   /** Implements IVertexSmearingTool::smearVertex.
    */
-  virtual StatusCode smearVertex(HepMC::GenEvent& theEvent);
+  StatusCode smearVertex(HepMC::GenEvent& theEvent) override;
 
 private:
   /// Minimum value for the x coordinate of the vertex (set by options)

--- a/Generation/src/components/GenAlg.h
+++ b/Generation/src/components/GenAlg.h
@@ -23,11 +23,11 @@ public:
   /// Constructor.
   GenAlg(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Tools to handle input from HepMC-file

--- a/Generation/src/components/GenMerge.h
+++ b/Generation/src/components/GenMerge.h
@@ -20,7 +20,7 @@ class MCParticleCollection;
 
 /** @class GenMerge
  *  @brief Algorithm merging two sets of MCParticle/Vertex-collections into one
- *  The main usecase, inspiring the member names, is overlaying generated pileup on a signal event. 
+ *  The main usecase, inspiring the member names, is overlaying generated pileup on a signal event.
  *  Note that collections cannot be modified once created, thus all data must be cloned into a new collections.
  *  Associations between particles and vertices are updated, so it is safe to drop the old collections.
  */
@@ -31,11 +31,11 @@ public:
   /// Constructor.
   GenMerge(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   DataHandle<fcc::GenVertexCollection> m_vertInSignal{"signalGenParticles", Gaudi::DataHandle::Reader, this};

--- a/Generation/src/components/GenParticleFilter.h
+++ b/Generation/src/components/GenParticleFilter.h
@@ -25,11 +25,11 @@ public:
   /// Constructor.
   GenParticleFilter(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute: Applies the filter
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Particle statuses to accept

--- a/Generation/src/components/HepMCDumper.h
+++ b/Generation/src/components/HepMCDumper.h
@@ -14,11 +14,11 @@ public:
   /// Constructor.
   HepMCDumper(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Handle for the HepMC to be read

--- a/Generation/src/components/HepMCFileReaderTool.h
+++ b/Generation/src/components/HepMCFileReaderTool.h
@@ -12,13 +12,13 @@ class HepMCFileReader : public GaudiTool, virtual public IHepMCProviderTool {
 public:
   HepMCFileReader(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~HepMCFileReader();  ///< Destructor
-  virtual StatusCode initialize();
-  virtual StatusCode finalize();
+  StatusCode initialize() override;
+  StatusCode finalize() override;
 
   /// Wrapper for HepMC's fill_next_event() --
   ///  as in the hepmc original, the user is responsible
   ///  for the deletion of the event returned from this function
-  virtual StatusCode getNextEvent(HepMC::GenEvent& event);
+  StatusCode getNextEvent(HepMC::GenEvent& event) override;
   /// Wrapper for HepMC file io.
 
 private:

--- a/Generation/src/components/HepMCFileWriter.h
+++ b/Generation/src/components/HepMCFileWriter.h
@@ -27,11 +27,11 @@ public:
   /// Constructor.
   HepMCFileWriter(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Handle for the HepMC to be read

--- a/Generation/src/components/HepMCFullMerge.h
+++ b/Generation/src/components/HepMCFullMerge.h
@@ -23,16 +23,16 @@ public:
 
   virtual ~HepMCFullMerge() final;
 
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
 
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
   /** Merge the events in the container into the signalEvent
    * For events in the vector, new vertices in signalEvent are created to which all pile-up particles are attached.
    *  @param[in/out] signalEvent is the signal event that will be enriched with puEvents from eventVector
    *  @param[in] eventVector is the vector of pile-up GenEvents
    */
-  virtual StatusCode merge(HepMC::GenEvent& signalEvent, const std::vector<HepMC::GenEvent>& eventVector) final;
+  StatusCode merge(HepMC::GenEvent& signalEvent, const std::vector<HepMC::GenEvent>& eventVector) override final;
 };
 
 #endif  // GENERATION_HEPMCFULLMERGE_H

--- a/Generation/src/components/HepMCHistograms.h
+++ b/Generation/src/components/HepMCHistograms.h
@@ -15,11 +15,11 @@ public:
   /// Constructor.
   HepMCHistograms(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Handle for the HepMC to be read

--- a/Generation/src/components/HepMCSimpleMerge.h
+++ b/Generation/src/components/HepMCSimpleMerge.h
@@ -17,16 +17,16 @@ public:
 
   virtual ~HepMCSimpleMerge() final;
 
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
 
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
   /** Merge the events in the container into the signalEvent
    * For events in the vector, new vertices in signalEvent are created to which the final-state particles are attached.
    *  @param[in/out] signalEvent is the signal event that will be enriched with puEvents from eventVector
    *  @param[in] eventVector is the vector of pile-up GenEvents
    */
-  virtual StatusCode merge(HepMC::GenEvent& signalEvent, const std::vector<HepMC::GenEvent>& eventVector) final;
+  StatusCode merge(HepMC::GenEvent& signalEvent, const std::vector<HepMC::GenEvent>& eventVector) override final;
 };
 
 #endif  // GENERATION_HEPMCPILEMERGETOOL_H

--- a/Generation/src/components/HepMCToEDMConverter.h
+++ b/Generation/src/components/HepMCToEDMConverter.h
@@ -18,11 +18,11 @@ public:
   /// Constructor.
   HepMCToEDMConverter(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Handle for the HepMC to be read

--- a/Generation/src/components/MomentumRangeParticleGun.h
+++ b/Generation/src/components/MomentumRangeParticleGun.h
@@ -27,14 +27,14 @@ public:
   virtual ~MomentumRangeParticleGun();
 
   /// Initialize particle gun parameters
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
 
   /// Generation of particles
-  virtual void generateParticle(Gaudi::LorentzVector& momentum, Gaudi::LorentzVector& origin, int& pdgId);
+  void generateParticle(Gaudi::LorentzVector& momentum, Gaudi::LorentzVector& origin, int& pdgId) override;
 
   /// Print counters
-  virtual void printCounters() { ; };
-  virtual StatusCode getNextEvent(HepMC::GenEvent&);
+  void printCounters() override { ; };
+  StatusCode getNextEvent(HepMC::GenEvent&) override;
 
 private:
   /// Minimum momentum (Set by options)

--- a/Generation/src/components/PoissonPileUp.h
+++ b/Generation/src/components/PoissonPileUp.h
@@ -23,15 +23,15 @@ public:
 
   virtual ~PoissonPileUp();
 
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
 
-  virtual unsigned int numberOfPileUp();
+  unsigned int numberOfPileUp() override;
 
-  virtual double getMeanPileUp();
+  double getMeanPileUp() override;
 
-  virtual void printPileUpCounters();
+  void printPileUpCounters() override;
 
-  virtual std::string getFilename();
+  std::string getFilename() override;
 
 private:
   /// average number of min bias events to pile on signal event.

--- a/Generation/src/components/PythiaInterface.h
+++ b/Generation/src/components/PythiaInterface.h
@@ -29,9 +29,9 @@ class PythiaInterface : public GaudiTool, virtual public IHepMCProviderTool {
 public:
   /// Constructor.
   PythiaInterface(const std::string& type, const std::string& name, const IInterface* parent);
-  virtual StatusCode initialize();
-  virtual StatusCode finalize();
-  virtual StatusCode getNextEvent(HepMC::GenEvent& theEvent);
+  StatusCode initialize() override;
+  StatusCode finalize() override;
+  StatusCode getNextEvent(HepMC::GenEvent& theEvent) override;
 
 private:
   /// Pythia8 engine

--- a/Reconstruction/RecCalorimeter/CMakeLists.txt
+++ b/Reconstruction/RecCalorimeter/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(HepMC)
 find_package(DD4hep COMPONENTS DDSegmentation)
 find_package(Geant4)
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${Geant4_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_module(RecCalorimeterPlugins
                  src/components/*.cpp
                  INCLUDE_DIRS FastJet ROOT FWCore HepMC FCCEDM PODIO DD4hep DetInterface DetSegmentation Geant4 DetCommon RecInterface RecCalorimeter

--- a/Reconstruction/RecCalorimeter/src/components/CalibrateCaloHitsTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/CalibrateCaloHitsTool.h
@@ -25,12 +25,12 @@ class CalibrateCaloHitsTool : public GaudiTool, virtual public ICalibrateCaloHit
 public:
   CalibrateCaloHitsTool(const std::string& type, const std::string& name, const IInterface* parent);
   ~CalibrateCaloHitsTool() = default;
-  virtual StatusCode initialize() final;
-  virtual StatusCode finalize() final;
+  StatusCode initialize() override final;
+  StatusCode finalize() override final;
 
   /** @brief  Calibrate Geant4 hit energy to EM scale
    */
-  virtual void calibrate(std::unordered_map<uint64_t, double>& aHits) final;
+  void calibrate(std::unordered_map<uint64_t, double>& aHits) override final;
 
 private:
   /// Value of 1/sampling fraction

--- a/Reconstruction/RecCalorimeter/src/components/CalibrateInLayersTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/CalibrateInLayersTool.h
@@ -32,15 +32,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
   /** @brief  Calibrate Geant4 hit energy to EM scale
    */
-  virtual void calibrate(std::unordered_map<uint64_t, double>& aHits) final;
+  void calibrate(std::unordered_map<uint64_t, double>& aHits) override final;
 
 private:
   /// Pointer to the geometry service

--- a/Reconstruction/RecCalorimeter/src/components/CreateCaloCells.h
+++ b/Reconstruction/RecCalorimeter/src/components/CreateCaloCells.h
@@ -43,11 +43,11 @@ class CreateCaloCells : public GaudiAlgorithm {
 public:
   CreateCaloCells(const std::string& name, ISvcLocator* svcLoc);
 
-  StatusCode initialize();
+  StatusCode initialize() override;
 
-  StatusCode execute();
+  StatusCode execute() override;
 
-  StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Handle for tool to calibrate Geant4 energy to EM scale tool

--- a/Reconstruction/RecCalorimeter/src/components/CreateCaloClustersSlidingWindow.h
+++ b/Reconstruction/RecCalorimeter/src/components/CreateCaloClustersSlidingWindow.h
@@ -69,16 +69,16 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  StatusCode initialize();
+  StatusCode initialize() override;
   /**  Execute.
    *   Perform the sliding window algorithm and build clusters.
    *   @return status code
    */
-  StatusCode execute();
+  StatusCode execute() override;
   /**  Finalize.
    *   @return status code
    */
-  StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /**  Correct way to access the neighbour of the phi tower, taking into account the full coverage in phi.

--- a/Reconstruction/RecCalorimeter/src/components/HepMCJetClustering.h
+++ b/Reconstruction/RecCalorimeter/src/components/HepMCJetClustering.h
@@ -15,11 +15,11 @@ public:
   /// Constructor.
   HepMCJetClustering(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Handle for the HepMC to be read

--- a/Reconstruction/RecCalorimeter/src/components/JetClustering.h
+++ b/Reconstruction/RecCalorimeter/src/components/JetClustering.h
@@ -25,9 +25,9 @@ class JetClustering : public GaudiAlgorithm {
 public:
   JetClustering(const std::string& name, ISvcLocator* svcLoc);
   virtual ~JetClustering() {}
-  virtual StatusCode initialize();
-  virtual StatusCode execute();
-  virtual StatusCode finalize();
+  virtual StatusCode initialize() override;
+  virtual StatusCode execute() override;
+  virtual StatusCode finalize() override;
 
 private:
   /// Handle for the particles to be read

--- a/Reconstruction/RecCalorimeter/src/components/JetHistograms.h
+++ b/Reconstruction/RecCalorimeter/src/components/JetHistograms.h
@@ -15,11 +15,11 @@ public:
   /// Constructor.
   JetHistograms(const std::string& name, ISvcLocator* svcLoc);
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute.
-  virtual StatusCode execute();
+  StatusCode execute() override;
   /// Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Handle for the HepMC to be read

--- a/Reconstruction/RecCalorimeter/src/components/NestedVolumesCaloTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/NestedVolumesCaloTool.h
@@ -23,8 +23,8 @@ class NestedVolumesCaloTool : public GaudiTool, virtual public ICalorimeterTool 
 public:
   NestedVolumesCaloTool(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~NestedVolumesCaloTool() = default;
-  virtual StatusCode initialize() final;
-  virtual StatusCode finalize() final;
+  StatusCode initialize() override final;
+  StatusCode finalize() override final;
   /** Prepare a map of all existing cells in current geometry.
    *   Active volumes are looked in the geometry manager by name ('\b activeVolumeName').
    *   Corresponding bitfield name is given in '\b activeFieldName'.
@@ -33,7 +33,7 @@ public:
    *   @param[out] aCells map of existing cells (and deposited energy, set to 0)
    *   return Status code.
    */
-  virtual StatusCode prepareEmptyCells(std::unordered_map<uint64_t, double>& aCells) final;
+  StatusCode prepareEmptyCells(std::unordered_map<uint64_t, double>& aCells) override final;
 
 private:
   /// Pointer to the geometry service

--- a/Reconstruction/RecCalorimeter/src/components/NoiseCaloCellsFlatTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/NoiseCaloCellsFlatTool.h
@@ -24,16 +24,16 @@ class NoiseCaloCellsFlatTool : public GaudiTool, virtual public INoiseCaloCellsT
 public:
   NoiseCaloCellsFlatTool(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~NoiseCaloCellsFlatTool() = default;
-  virtual StatusCode initialize() final;
-  virtual StatusCode finalize() final;
+  StatusCode initialize() override final;
+  StatusCode finalize() override final;
 
   /** @brief Create random CaloHits (gaussian distribution) for the vector of cells (aCells).
    * Vector of cells must contain all cells in the calorimeter with their cellIDs.
    */
-  virtual void addRandomCellNoise(std::unordered_map<uint64_t, double>& aCells) final;
+  void addRandomCellNoise(std::unordered_map<uint64_t, double>& aCells) override final;
   /** @brief Remove cells with energy bellow threshold*sigma from the vector of cells
    */
-  virtual void filterCellNoise(std::unordered_map<uint64_t, double>& aCells) final;
+  void filterCellNoise(std::unordered_map<uint64_t, double>& aCells) override final;
 
 private:
   /// Sigma of noise -- uniform noise per cell in GeV

--- a/Reconstruction/RecCalorimeter/src/components/NoiseCaloCellsFromFileTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/NoiseCaloCellsFromFileTool.h
@@ -30,16 +30,16 @@ class NoiseCaloCellsFromFileTool : public GaudiTool, virtual public INoiseCaloCe
 public:
   NoiseCaloCellsFromFileTool(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~NoiseCaloCellsFromFileTool() = default;
-  virtual StatusCode initialize() final;
-  virtual StatusCode finalize() final;
+  StatusCode initialize() override final;
+  StatusCode finalize() override final;
 
   /** @brief Create random CaloHits (gaussian distribution) for the vector of cells (aCells).
    * Vector of cells must contain all cells in the calorimeter with their cellIDs.
    */
-  virtual void addRandomCellNoise(std::unordered_map<uint64_t, double>& aCells) final;
+  void addRandomCellNoise(std::unordered_map<uint64_t, double>& aCells) override final;
   /** @brief Remove cells with energy bellow threshold*sigma from the vector of cells
    */
-  virtual void filterCellNoise(std::unordered_map<uint64_t, double>& aCells) final;
+  void filterCellNoise(std::unordered_map<uint64_t, double>& aCells) override final;
 
   /// Open file and read noise histograms in the memory
   StatusCode initNoiseFromFile();

--- a/Reconstruction/RecCalorimeter/src/components/SingleCaloTowerTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/SingleCaloTowerTool.h
@@ -30,7 +30,7 @@ class Segmentation;
  *  A tower contains all cells within certain eta and phi (tower size: '\b
  * deltaEtaTower', '\b deltaPhiTower').
  *  Distance in r plays no role, however `\b radiusForPosition` needs to be
- *  defined (e.g. to inner radius of the detector) for the cluster position 
+ *  defined (e.g. to inner radius of the detector) for the cluster position
  *  calculation. By default the radius is equal to 1.
  *
  *  This tool creates towers from a single cell collection (from one
@@ -50,11 +50,11 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
   /**  Find number of calorimeter towers.
    *   Number of towers in phi is calculated from full azimuthal angle (2 pi)
    * and the size of tower in phi ('\b deltaPhiTower').
@@ -62,14 +62,14 @@ public:
    * etaMax`) and the size of tower in eta ('\b deltaEtaTower').
    *   @return Struct containing number of towers in eta and phi.
    */
-  virtual tower towersNumber() final;
+  tower towersNumber() override final;
   /**  Build calorimeter towers.
-   *   Tower is segmented in eta and phi, with the energy from all layers 
+   *   Tower is segmented in eta and phi, with the energy from all layers
    *   (no segmentation).
    *   @param[out] aTowers Calorimeter towers.
    *   @return Size of the cell collection.
    */
-  virtual uint buildTowers(std::vector<std::vector<float>>& aTowers) final;
+  uint buildTowers(std::vector<std::vector<float>>& aTowers) override final;
   /**  Get the radius (in mm) for the position calculation.
    *   Reconstructed cluster has eta and phi position, without the radial
    * coordinate. The cluster in EDM contains
@@ -77,12 +77,12 @@ public:
    * calorimeter) needs to be specified. By default it is equal to 1.
    *   @return Radius
    */
-  virtual float radiusForPosition() const final;
+  float radiusForPosition() const override final;
   /**  Get the tower IDs in eta.
    *   @param[in] aEta Position of the calorimeter cell in eta
    *   @return ID (eta) of a tower
    */
-  virtual uint idEta(float aEta) const final;
+  uint idEta(float aEta) const override final;
   /**  Get the tower IDs in phi.
    *   Tower IDs are shifted so they start at 0 (middle of cell with ID=0 is
    * phi=0, phi is defined form -pi to pi). No
@@ -90,26 +90,26 @@ public:
    *   @param[in] aPhi Position of the calorimeter cell in phi
    *   @return ID (phi) of a tower
    */
-  virtual uint idPhi(float aPhi) const final;
+  uint idPhi(float aPhi) const override final;
   /**  Get the eta position of the centre of the tower.
    *   Tower IDs are shifted so they start at 0 (middle of cell with ID=0 is
    * eta=0). No segmentation offset is taken into account.
    *   @param[in] aIdEta ID (eta) of a tower
    *   @return Position of the centre of the tower
    */
-  virtual float eta(int aIdEta) const final;
+  float eta(int aIdEta) const override final;
   /**  Get the phi position of the centre of the tower.
    *   @param[in] aIdPhi ID (phi) of a tower
    *   @return Position of the centre of the tower
    */
-  virtual float phi(int aIdPhi) const final;
+  float phi(int aIdPhi) const override final;
   /**  Correct way to access the neighbour of the phi tower, taking into account
    * the full coverage in phi.
    *   Full coverage means that first tower in phi, with ID = 0 is a direct
    * neighbour of the last tower in phi with ID = m_nPhiTower - 1).
-   *   @param[in] aIPhi requested ID of a phi tower, 
+   *   @param[in] aIPhi requested ID of a phi tower,
    *   may be < 0 or >=m_nPhiTower
-   *   @return  ID of a tower - shifted and corrected 
+   *   @return  ID of a tower - shifted and corrected
    * (in [0, m_nPhiTower) range)
    */
   uint phiNeighbour(int aIPhi) const;

--- a/Reconstruction/RecCalorimeter/src/components/TubeLayerPhiEtaCaloTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/TubeLayerPhiEtaCaloTool.h
@@ -22,8 +22,8 @@ class TubeLayerPhiEtaCaloTool : public GaudiTool, virtual public ICalorimeterToo
 public:
   TubeLayerPhiEtaCaloTool(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~TubeLayerPhiEtaCaloTool() = default;
-  virtual StatusCode initialize() final;
-  virtual StatusCode finalize() final;
+  StatusCode initialize() override final;
+  StatusCode finalize() override final;
   /** Prepare a map of all existing cells in current geometry.
    *   Active layers (cylindrical tubes) are looked in the geometry manager by name ('\b activeVolumeName').
    *   Corresponding bitfield name is given in '\b activeFieldName'.
@@ -36,7 +36,7 @@ public:
    *   @param[out] aCells map of existing cells (and deposited energy, set to 0)
    *   return Status code.
    */
-  virtual StatusCode prepareEmptyCells(std::unordered_map<uint64_t, double>& aCells) final;
+  StatusCode prepareEmptyCells(std::unordered_map<uint64_t, double>& aCells) override final;
 
 private:
   /// Pointer to the geometry service

--- a/Reconstruction/RecTracker/CMakeLists.txt
+++ b/Reconstruction/RecTracker/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(ROOT)
 
 
 gaudi_install_headers(RecTracker)
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_library(TrackingUtils
                  src/lib/*.cpp
                  INCLUDE_DIRS ROOT FWCore HepMC FCCEDM PODIO DD4hep DetInterface RecInterface

--- a/Reconstruction/RecTracker/src/components/FastGaussSmearDigi.h
+++ b/Reconstruction/RecTracker/src/components/FastGaussSmearDigi.h
@@ -22,11 +22,11 @@ public:
 
   ~FastGaussSmearDigi();
 
-  StatusCode initialize();
+  StatusCode initialize() override;
 
-  StatusCode execute();
+  StatusCode execute() override;
 
-  StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// Pointer to the geometry service

--- a/Sim/SimDelphesInterface/CMakeLists.txt
+++ b/Sim/SimDelphesInterface/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(PODIO)
 find_package(ROOT COMPONENTS Physics EG)
 find_package(HepMC)
 
+include_directories(SYSTEM ${DELPHES_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS} "$ENV{HEPMC_PREFIX}/include")
+
 gaudi_add_module(SimDelphesInterface
                  src/*.cpp
                  INCLUDE_DIRS FWCore ROOT Delphes FCCEDM PODIO HepMC

--- a/Sim/SimDelphesInterface/src/DelphesSaveChargedParticles.h
+++ b/Sim/SimDelphesInterface/src/DelphesSaveChargedParticles.h
@@ -29,11 +29,11 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /**  Save Delphes collection to EDM.
    *   Converts charged particles to fcc::Particle and creates associations to fcc::MCParticle
    *   If isolation tags are defined, they are also translated and associations are created.
@@ -42,7 +42,7 @@ public:
    * point)
    *   @return status code
    */
-  virtual StatusCode saveOutput(Delphes& delphes, const fcc::MCParticleCollection& mcParticles) final;
+  StatusCode saveOutput(Delphes& delphes, const fcc::MCParticleCollection& mcParticles) override final;
 
 private:
   /// Handle the particles to be saved

--- a/Sim/SimDelphesInterface/src/DelphesSaveGenJets.h
+++ b/Sim/SimDelphesInterface/src/DelphesSaveGenJets.h
@@ -30,11 +30,11 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /**  Save Delphes collection to EDM.
    *   Converts genJets to fcc::GenJet and creates associations to fcc::MCParticle
    *   If flavor tags are defined, they are also translated and associations are created.
@@ -43,7 +43,7 @@ public:
    * point)
    *   @return status code
    */
-  virtual StatusCode saveOutput(Delphes& delphes, const fcc::MCParticleCollection& mcParticles) final;
+  StatusCode saveOutput(Delphes& delphes, const fcc::MCParticleCollection& mcParticles) override final;
 
 private:
   //! Recursive method to find an id of MCParticle related to the given Delphes Candidate object,

--- a/Sim/SimDelphesInterface/src/DelphesSaveJets.h
+++ b/Sim/SimDelphesInterface/src/DelphesSaveJets.h
@@ -30,11 +30,11 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /**  Save Delphes collection to EDM.
    *   Converts genJets to fcc::Jet and creates associations to fcc::MCParticle
    *   If flavor tags are defined, they are also translated and associations are created.
@@ -43,7 +43,7 @@ public:
    * point)
    *   @return status code
    */
-  virtual StatusCode saveOutput(Delphes& delphes, const fcc::MCParticleCollection& mcParticles) final;
+  StatusCode saveOutput(Delphes& delphes, const fcc::MCParticleCollection& mcParticles) override final;
 
 private:
   /// Handle to the jets to be saved

--- a/Sim/SimDelphesInterface/src/DelphesSaveMet.h
+++ b/Sim/SimDelphesInterface/src/DelphesSaveMet.h
@@ -27,18 +27,18 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /**  Save Delphes collection to EDM.
    *   Converts met to fcc::MET and creates associations to fcc::MCParticle
    *   @param[in] delphes: reference to Delphes module
    *   @param[in] mcParticles: Not used here will vanish in the future: (FIXME: will be input at some point)
    *   @return status code
    */
-  virtual StatusCode saveOutput(Delphes& delphes, const fcc::MCParticleCollection& mcParticles) final;
+  StatusCode saveOutput(Delphes& delphes, const fcc::MCParticleCollection& mcParticles) override final;
 
 private:
   /// Handle the METs to be saved

--- a/Sim/SimDelphesInterface/src/DelphesSaveNeutralParticles.h
+++ b/Sim/SimDelphesInterface/src/DelphesSaveNeutralParticles.h
@@ -29,11 +29,11 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /**  Save Delphes collection to EDM.
    *   Converts neutral particles to fcc::Particle and creates associations to fcc::MCParticle
    *   If isolation switch is true, isolation tags are also translated and associations are created.
@@ -42,7 +42,7 @@ public:
    * point)
    *   @return status code
    */
-  virtual StatusCode saveOutput(Delphes& delphes, const fcc::MCParticleCollection& mcParticles) final;
+  StatusCode saveOutput(Delphes& delphes, const fcc::MCParticleCollection& mcParticles) override final;
 
 private:
   /// Handle the particles to be saved

--- a/Sim/SimDelphesInterface/src/DelphesSimulation.h
+++ b/Sim/SimDelphesInterface/src/DelphesSimulation.h
@@ -60,15 +60,15 @@ public:
   DelphesSimulation(const std::string& name, ISvcLocator* svcLoc);
 
   //! Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
 
   //! Execute. This function actually does no simulation,
   //! and simply converts the stable MCParticles in the input collection
   //! into Particles that are written to the output collection.
-  virtual StatusCode execute();
+  StatusCode execute() override;
 
   //! Finalize.
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   //! Recursive method to find an id of MCParticle related to the given Delphes Candidate object,

--- a/Sim/SimG4Common/SimG4Common/ConstantField.h
+++ b/Sim/SimG4Common/SimG4Common/ConstantField.h
@@ -24,7 +24,7 @@ public:
   /// Get the value of the magnetic field value at position
   /// @param[in] point the position where the field is to be returned
   /// @param[out] bField the return value
-  virtual void GetFieldValue(const G4double point[4], double* bField) const final;
+  void GetFieldValue(const G4double point[4], double* bField) const override final;
 
   /// Set the x component of the field
   void setBx(double value) { m_bX = value; }

--- a/Sim/SimG4Common/SimG4Common/ParticleInformation.h
+++ b/Sim/SimG4Common/SimG4Common/ParticleInformation.h
@@ -32,7 +32,7 @@ public:
   /// A destructor
   virtual ~ParticleInformation();
   /// A printing method
-  virtual void Print() const final;
+  void Print() const override final;
   /** Getter of the MCParticle.
    *  @returns EDM MCParticle.
    */

--- a/Sim/SimG4Components/CMakeLists.txt
+++ b/Sim/SimG4Components/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(ROOT COMPONENTS MathCore GenVector Geom REQUIRED)
 gaudi_install_headers(SimG4Components)
 gaudi_install_python_modules()
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_module(SimG4Components
                  src/*.cpp
                  INCLUDE_DIRS Geant4 FWCore SimG4Common SimG4Interface DD4hep ROOT

--- a/Sim/SimG4Components/src/SimG4Alg.h
+++ b/Sim/SimG4Components/src/SimG4Alg.h
@@ -39,7 +39,7 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Execute the simulation.
    *   Translation of MCParticleCollection to G4Event is done using EDM2G4() method.
    *   Then, G4Event is passed to SimG4Svc for the simulation and retrieved afterwards.
@@ -47,11 +47,11 @@ public:
    *   Finally, the event is terminated.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  StatusCode execute() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
 private:
   /// Pointer to the interface of Geant simulation service

--- a/Sim/SimG4Components/src/SimG4ConstantMagneticFieldTool.h
+++ b/Sim/SimG4Components/src/SimG4ConstantMagneticFieldTool.h
@@ -37,14 +37,14 @@ public:
   virtual ~SimG4ConstantMagneticFieldTool();
 
   /// Initialize method
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
 
   /// Finalize method
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
   /// Get the magnetic field
   /// @returns pointer to G4MagneticField
-  virtual const G4MagneticField* field() const final;
+  const G4MagneticField* field() const override final;
 
   /// Get the stepper
   /// @returns pointer to G4MagIntegratorStepper (ownership is transferred to the caller)

--- a/Sim/SimG4Components/src/SimG4DD4hepDetector.h
+++ b/Sim/SimG4Components/src/SimG4DD4hepDetector.h
@@ -23,15 +23,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /** Get the initilization of the geometry.
    *  @return pointer to G4VUserDetectorConstruction (ownership is transferred to the caller)
    */
-  virtual G4VUserDetectorConstruction* detectorConstruction();
+  G4VUserDetectorConstruction* detectorConstruction() override;
 
 private:
   /// Pointer to the geometry service

--- a/Sim/SimG4Components/src/SimG4FtfpBert.h
+++ b/Sim/SimG4Components/src/SimG4FtfpBert.h
@@ -20,15 +20,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /** Get the physics list.
    *  @return pointer to G4VModularPhysicsList (ownership is transferred to the caller)
    */
-  virtual G4VModularPhysicsList* physicsList();
+  G4VModularPhysicsList* physicsList() override;
 };
 
 #endif /* SIMG4COMPONENTS_G4FTFPBERT_H */

--- a/Sim/SimG4Components/src/SimG4GdmlDetector.h
+++ b/Sim/SimG4Components/src/SimG4GdmlDetector.h
@@ -25,15 +25,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /** Get the initilization of the geometry.
    *  @return pointer to G4VUserDetectorConstruction (ownership is transferred to the caller)
    */
-  virtual G4VUserDetectorConstruction* detectorConstruction();
+  G4VUserDetectorConstruction* detectorConstruction() override;
 
 private:
   /// name of the GDML file

--- a/Sim/SimG4Components/src/SimG4PrimariesFromEdmTool.h
+++ b/Sim/SimG4Components/src/SimG4PrimariesFromEdmTool.h
@@ -27,13 +27,13 @@ public:
   /// Standard constructor
   SimG4PrimariesFromEdmTool(const std::string& type, const std::string& name, const IInterface* parent);
 
-  virtual ~SimG4PrimariesFromEdmTool();
+  ~SimG4PrimariesFromEdmTool();
 
-  StatusCode initialize() final;
+  StatusCode initialize() override final;
 
   /// Translates the input (fcc::MCParticleCollection) into a G4Event
   /// @returns G4Event with primaries generated from MCParticleCollection (ownership is transferred to the caller)
-  virtual G4Event* g4Event() final;
+  G4Event* g4Event() override final;
 
 private:
   /// Handle for the EDM MC particles to be read

--- a/Sim/SimG4Components/src/SimG4SaveCalHits.h
+++ b/Sim/SimG4Components/src/SimG4SaveCalHits.h
@@ -34,17 +34,17 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /**  Save the data output.
    *   Saves the calorimeter hits from the collections as specified in the job options in \b'readoutNames'.
    *   @param[in] aEvent Event with data to save.
    *   @return status code
    */
-  virtual StatusCode saveOutput(const G4Event& aEvent) final;
+  StatusCode saveOutput(const G4Event& aEvent) override final;
 
 private:
   /// Pointer to the geometry service

--- a/Sim/SimG4Components/src/SimG4SaveSmearedParticles.h
+++ b/Sim/SimG4Components/src/SimG4SaveSmearedParticles.h
@@ -28,17 +28,17 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /**  Save the data output.
    *   Saves the 'reconstructed' (smeared) particles and associates them with MC particles.
    *   @param[in] aEvent Event with data to save.
    *   @return status code
    */
-  virtual StatusCode saveOutput(const G4Event& aEvent) final;
+  StatusCode saveOutput(const G4Event& aEvent) override final;
 
 private:
   /// Handle for the particles to be written

--- a/Sim/SimG4Components/src/SimG4SaveTrackerHits.h
+++ b/Sim/SimG4Components/src/SimG4SaveTrackerHits.h
@@ -34,17 +34,17 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /**  Save the data output.
    *   Saves the tracker hits from the collections as specified in the job options in \b'readoutNames'.
    *   @param[in] aEvent Event with data to save.
    *   @return status code
    */
-  virtual StatusCode saveOutput(const G4Event& aEvent) final;
+  StatusCode saveOutput(const G4Event& aEvent) override final;
 
 private:
   /// Pointer to the geometry service

--- a/Sim/SimG4Components/src/SimG4SingleParticleGeneratorTool.h
+++ b/Sim/SimG4Components/src/SimG4SingleParticleGeneratorTool.h
@@ -35,14 +35,14 @@ public:
   /// Standard constructor
   SimG4SingleParticleGeneratorTool(const std::string& type, const std::string& name, const IInterface* parent);
 
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
 
   /// Destructor
   virtual ~SimG4SingleParticleGeneratorTool();
 
   /// Generates primaries using the parameters set via options file, uses CLHEP:RandFlat random number generator
   /// @returns G4Event with primaries generated through G4ParticleGun (ownership is transferred to the caller)
-  virtual G4Event* g4Event() final;
+  G4Event* g4Event() override final;
 
 private:
   /// Saves primary vertex and particle to FCC EDM (called if property saveEDM is set to true)

--- a/Sim/SimG4Components/src/SimG4Svc.h
+++ b/Sim/SimG4Components/src/SimG4Svc.h
@@ -34,25 +34,25 @@ public:
    *   physics list and user action initialization to initialize G4RunManager.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize the Geant simulation service.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
   /**  Simulate the event with Geant.
    *   @param[in] aEvent An event to be processed.
    *   @return status code
    */
-  StatusCode processEvent(G4Event& aEvent);
+  StatusCode processEvent(G4Event& aEvent) override;
   /**  Retrieve the processed event.
    *   @param[out] aEvent The processed event.
    *   @return status code
    */
-  StatusCode retrieveEvent(G4Event*& aEvent);
+  StatusCode retrieveEvent(G4Event*& aEvent) override;
   /**  Terminate the event simulation.
    *   @return status code
    */
-  StatusCode terminateEvent();
+  StatusCode terminateEvent() override;
 
 private:
   /// Pointer to the tool service

--- a/Sim/SimG4Fast/CMakeLists.txt
+++ b/Sim/SimG4Fast/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(ROOT COMPONENTS Tree)
 
 gaudi_install_headers(SimG4Fast)
 
+include_directories(SYSTEM ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_library(SimG4Fast
                  src/lib/*.cpp
                  INCLUDE_DIRS SimG4Common FWCore SimG4Components SimG4Interface Geant4 ROOT

--- a/Sim/SimG4Fast/SimG4Fast/FastSimActions.h
+++ b/Sim/SimG4Fast/SimG4Fast/FastSimActions.h
@@ -17,7 +17,7 @@ public:
   explicit FastSimActions();
   virtual ~FastSimActions();
   /// Create all user actions.
-  virtual void Build() const final;
+  void Build() const override final;
 };
 }
 

--- a/Sim/SimG4Fast/SimG4Fast/FastSimModelTracker.h
+++ b/Sim/SimG4Fast/SimG4Fast/FastSimModelTracker.h
@@ -57,18 +57,18 @@ public:
   /** Check if this model should be applied to this particle type.
    *  @param aParticle Particle definition (type).
    */
-  virtual G4bool IsApplicable(const G4ParticleDefinition& aParticle) final;
+  G4bool IsApplicable(const G4ParticleDefinition& aParticle) override final;
   /** Check if the model should be applied taking into account the kinematics of a track.
    *  @param aFastTrack Track.
    */
-  virtual G4bool ModelTrigger(const G4FastTrack& aFastTrack) final;
+  G4bool ModelTrigger(const G4FastTrack& aFastTrack) override final;
   /** Apply the parametrisation.
    *  Move the particle to the exit from the volume along the computed trajectory.
    *  Smear the momentum with the smearing tool m_smearTool.
    *  @param aFastTrack Track.
    *  @param aFastStep Step.
    */
-  virtual void DoIt(const G4FastTrack& aFastTrack, G4FastStep& aFastStep) final;
+  void DoIt(const G4FastTrack& aFastTrack, G4FastStep& aFastStep) override final;
 
 private:
   /// Message Service

--- a/Sim/SimG4Fast/SimG4Fast/FastSimPhysics.h
+++ b/Sim/SimG4Fast/SimG4Fast/FastSimPhysics.h
@@ -26,9 +26,9 @@ public:
   /* Add the process of parametrisation to every existing particle
   * (created by the G4ModularPhysicsList to which it is registered)
   */
-  virtual void ConstructProcess() final;
+  void ConstructProcess() override final;
   /// Construction of particles. Nothing to be done by fast sim (parametrisation).
-  virtual void ConstructParticle() final;
+  void ConstructParticle() override final;
 };
 }
 

--- a/Sim/SimG4Fast/src/components/SimG4FastSimActions.h
+++ b/Sim/SimG4Fast/src/components/SimG4FastSimActions.h
@@ -22,15 +22,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
   /** Get the user action initialization.
    *  @return pointer to G4VUserActionInitialization (ownership is transferred to the caller)
    */
-  virtual G4VUserActionInitialization* userActionInitialization() final;
+  G4VUserActionInitialization* userActionInitialization() override final;
 };
 
 #endif /* SIMG4FAST_G4FASTSIMACTIONS_H */

--- a/Sim/SimG4Fast/src/components/SimG4FastSimCalorimeterRegion.h
+++ b/Sim/SimG4Fast/src/components/SimG4FastSimCalorimeterRegion.h
@@ -35,15 +35,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
   /**  Create regions and fast simulation models
    *   @return status code
    */
-  virtual StatusCode create() final;
+  StatusCode create() override final;
   /**  Get the names of the volumes where fast simulation should be performed.
    *   @return vector of volume names
    */

--- a/Sim/SimG4Fast/src/components/SimG4FastSimHistograms.h
+++ b/Sim/SimG4Fast/src/components/SimG4FastSimHistograms.h
@@ -32,15 +32,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Fills the histograms.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  StatusCode execute() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
 private:
   /// Handle for the EDM particles and MC particles associations to be read

--- a/Sim/SimG4Fast/src/components/SimG4FastSimPhysicsList.h
+++ b/Sim/SimG4Fast/src/components/SimG4FastSimPhysicsList.h
@@ -24,15 +24,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /** Get the physics list.
    *  @return pointer to G4VModularPhysicsList (ownership is transferred to the caller)
    */
-  virtual G4VModularPhysicsList* physicsList();
+  G4VModularPhysicsList* physicsList() override;
 
 private:
   /// Handle for the full physics list tool

--- a/Sim/SimG4Fast/src/components/SimG4FastSimTrackerRegion.h
+++ b/Sim/SimG4Fast/src/components/SimG4FastSimTrackerRegion.h
@@ -31,15 +31,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
   /**  Create regions and fast simulation models
    *   @return status code
    */
-  virtual StatusCode create() final;
+  StatusCode create() override final;
   /**  Get the names of the volumes where fast simulation should be performed.
    *   @return vector of volume names
    */

--- a/Sim/SimG4Fast/src/components/SimG4GflashHomoCalo.h
+++ b/Sim/SimG4Fast/src/components/SimG4GflashHomoCalo.h
@@ -23,15 +23,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
   /**  Get the parametrisation
    *   @return unique pointer to the parametrisation
    */
-  virtual std::unique_ptr<GVFlashShowerParameterisation> parametrisation() final;
+  std::unique_ptr<GVFlashShowerParameterisation> parametrisation() override final;
 
 private:
   /// Material name of the homogenous calorimeter (to be searched for in Geant NIST table)

--- a/Sim/SimG4Fast/src/components/SimG4GflashSamplingCalo.h
+++ b/Sim/SimG4Fast/src/components/SimG4GflashSamplingCalo.h
@@ -25,15 +25,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
   /**  Get the parametrisation
    *   @return unique pointer to the parametrisation
    */
-  virtual std::unique_ptr<GVFlashShowerParameterisation> parametrisation() final;
+  std::unique_ptr<GVFlashShowerParameterisation> parametrisation() override final;
 
 private:
   /// Material name of the active layer in the sampling calorimeter (to be searched for in Geant NIST table)

--- a/Sim/SimG4Fast/src/components/SimG4ParticleSmearFormula.h
+++ b/Sim/SimG4Fast/src/components/SimG4ParticleSmearFormula.h
@@ -31,18 +31,18 @@ public:
   /**  Initialize the tool and a random number generator.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
   /**  Smear the momentum of the particle
    *   @param aMom Particle momentum to be smeared.
    *   @param[in] aPdg Particle PDG code.
    *   @return status code
    */
-  virtual StatusCode smearMomentum(CLHEP::Hep3Vector& aMom, int aPdg = 0) final;
+  StatusCode smearMomentum(CLHEP::Hep3Vector& aMom, int aPdg = 0) override final;
 
   /**  Check conditions of the smearing model, especially if the given parametrs do not exceed the parameters of the
    * model.
@@ -51,7 +51,7 @@ public:
    *   @param[in] aMaxEta Maximum pseudorapidity.
    *   @return status code
    */
-  inline virtual StatusCode checkConditions(double, double, double) const final { return StatusCode::SUCCESS; }
+  inline StatusCode checkConditions(double, double, double) const override final { return StatusCode::SUCCESS; }
 
 private:
   /// TFormula representing resolution momentum-dependent for the smearing

--- a/Sim/SimG4Fast/src/components/SimG4ParticleSmearRootFile.h
+++ b/Sim/SimG4Fast/src/components/SimG4ParticleSmearRootFile.h
@@ -36,17 +36,17 @@ public:
   /**  Initialize the tool and a random number generator.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
   /**  Smear the momentum of the particle
    *   @param aMom Particle momentum to be smeared.
    *   @param[in] aPdg Particle PDG code.
    *   @return status code
    */
-  virtual StatusCode smearMomentum(CLHEP::Hep3Vector& aMom, int aPdg = 0) final;
+  StatusCode smearMomentum(CLHEP::Hep3Vector& aMom, int aPdg = 0) override final;
   /**  Read the file with the resolutions. File name is set by job options.
    *   @return status code
    */
@@ -65,7 +65,7 @@ public:
    *   @param[in] aMaxEta Maximum pseudorapidity.
    *   @return status code
    */
-  virtual StatusCode checkConditions(double aMinMomentum, double aMaxMomentum, double aMaxEta) const final;
+  StatusCode checkConditions(double aMinMomentum, double aMaxMomentum, double aMaxEta) const override final;
 
 private:
   /// Random Number Service

--- a/Sim/SimG4Fast/src/components/SimG4ParticleSmearSimple.h
+++ b/Sim/SimG4Fast/src/components/SimG4ParticleSmearSimple.h
@@ -27,18 +27,18 @@ public:
   /**  Initialize the tool and a random number generator.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
   /**  Smear the momentum of the particle
    *   @param aMom Particle momentum to be smeared.
    *   @param[in] aPdg Particle PDG code.
    *   @return status code
    */
-  virtual StatusCode smearMomentum(CLHEP::Hep3Vector& aMom, int aPdg = 0) final;
+  StatusCode smearMomentum(CLHEP::Hep3Vector& aMom, int aPdg = 0) override final;
 
   /**  Check conditions of the smearing model, especially if the given parametrs do not exceed the parameters of the
    * model.
@@ -47,7 +47,7 @@ public:
    *   @param[in] aMaxEta Maximum pseudorapidity.
    *   @return status code
    */
-  inline virtual StatusCode checkConditions(double, double, double) const final { return StatusCode::SUCCESS; }
+  inline StatusCode checkConditions(double, double, double) const override final { return StatusCode::SUCCESS; }
 
 private:
   /// Random Number Service

--- a/Sim/SimG4Full/SimG4Full/FullSimActions.h
+++ b/Sim/SimG4Full/SimG4Full/FullSimActions.h
@@ -16,7 +16,7 @@ public:
   FullSimActions();
   virtual ~FullSimActions();
   /// Create all user actions.
-  virtual void Build() const final;
+  void Build() const override final;
 };
 }
 

--- a/Sim/SimG4Full/src/components/SimG4FullSimActions.h
+++ b/Sim/SimG4Full/src/components/SimG4FullSimActions.h
@@ -22,15 +22,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /** Get the user action initialization.
    *  @return pointer to G4VUserActionInitialization (ownership is transferred to the caller)
    */
-  virtual G4VUserActionInitialization* userActionInitialization() final;
+  G4VUserActionInitialization* userActionInitialization() override final;
 };
 
 #endif /* SIMG4FULL_G4FULLSIMACTIONS_H */

--- a/Test/TestGeometry/CMakeLists.txt
+++ b/Test/TestGeometry/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(ROOT COMPONENTS MathCore GenVector Geom REQUIRED)
 
 gaudi_install_headers(TestGeometry)
 
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_library(TestGeometry
 		  src/lib/*.cpp
 		  INCLUDE_DIRS Geant4 ROOT TestGeometry DD4hep

--- a/Test/TestGeometry/TestGeometry/TestCalorimeterSD.h
+++ b/Test/TestGeometry/TestGeometry/TestCalorimeterSD.h
@@ -23,8 +23,8 @@ public:
   TestCalorimeterSD(std::string name);
   TestCalorimeterSD(std::string name, int aCellNoInAxis);
   virtual ~TestCalorimeterSD();
-  virtual void Initialize(G4HCofThisEvent* HCE);
-  virtual G4bool ProcessHits(G4Step* aStep, G4TouchableHistory* ROhist);
+  void Initialize(G4HCofThisEvent* HCE) override;
+  G4bool ProcessHits(G4Step* aStep, G4TouchableHistory* ROhist) override;
 
 private:
   TestCalorimeterHitsCollection* m_HitsCollection;

--- a/Test/TestGeometry/TestGeometry/TestKillProcess.h
+++ b/Test/TestGeometry/TestGeometry/TestKillProcess.h
@@ -19,15 +19,15 @@ public:
   /// Destructor.
   virtual ~TestKillProcess(){};
   /// Add the custom process that deposits all energy in the vertex.
-  virtual G4VParticleChange* AtRestDoIt(const G4Track&, const G4Step&) final { return nullptr; };
-  virtual G4double AtRestGetPhysicalInteractionLength(const G4Track&, G4ForceCondition*) final { return -1; };
-  virtual G4VParticleChange* PostStepDoIt(const G4Track&, const G4Step&) final;
-  virtual G4double PostStepGetPhysicalInteractionLength(const G4Track&, G4double, G4ForceCondition*) final {
+  G4VParticleChange* AtRestDoIt(const G4Track&, const G4Step&) override final { return nullptr; };
+  G4double AtRestGetPhysicalInteractionLength(const G4Track&, G4ForceCondition*) override final { return -1; };
+  G4VParticleChange* PostStepDoIt(const G4Track&, const G4Step&) override final;
+  G4double PostStepGetPhysicalInteractionLength(const G4Track&, G4double, G4ForceCondition*) override final {
     return 0;
   };
-  virtual G4VParticleChange* AlongStepDoIt(const G4Track&, const G4Step&) final { return nullptr; };
-  virtual G4double AlongStepGetPhysicalInteractionLength(const G4Track&, G4double, G4double, G4double&,
-                                                         G4GPILSelection*) final {
+  G4VParticleChange* AlongStepDoIt(const G4Track&, const G4Step&) override final { return nullptr; };
+  G4double AlongStepGetPhysicalInteractionLength(const G4Track&, G4double, G4double, G4double&,
+                                                 G4GPILSelection*) override final {
     return -1;
   };
 };

--- a/Test/TestGeometry/TestGeometry/TestPhysicsList.h
+++ b/Test/TestGeometry/TestGeometry/TestPhysicsList.h
@@ -22,9 +22,9 @@ public:
   /// Destructor.
   virtual ~TestPhysicsList();
   /// Add the custom process that deposits all energy in the vertex.
-  virtual void ConstructProcess() final;
+  void ConstructProcess() override final;
   /// Construction of particles.
-  virtual void ConstructParticle() final;
+  void ConstructParticle() override final;
 
 private:
   TestKillProcess m_process;

--- a/Test/TestGeometry/src/components/SimG4GdmlTestDetector.h
+++ b/Test/TestGeometry/src/components/SimG4GdmlTestDetector.h
@@ -26,15 +26,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /** Get the initilization of the geometry.
    *  @return pointer to G4VUserDetectorConstruction
    */
-  virtual G4VUserDetectorConstruction* detectorConstruction();
+  G4VUserDetectorConstruction* detectorConstruction() override;
 
 private:
   /// name of the GDML file

--- a/Test/TestGeometry/src/components/SimG4SaveTestCalHits.h
+++ b/Test/TestGeometry/src/components/SimG4SaveTestCalHits.h
@@ -29,18 +29,18 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /**  Save the data output.
    *   Saves the calorimeter hits and clusters from every hits collection associated with the event
    *   that has m_calType in its name.
    *   @param[in] aEvent Event with data to save.
    *   @return status code
    */
-  virtual StatusCode saveOutput(const G4Event& aEvent) final;
+  StatusCode saveOutput(const G4Event& aEvent) override final;
 
 private:
   /// Handle for calo clusters

--- a/Test/TestGeometry/src/components/SimG4TestPhysicsList.h
+++ b/Test/TestGeometry/src/components/SimG4TestPhysicsList.h
@@ -20,15 +20,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize();
+  StatusCode finalize() override;
   /** Get the physics list.
    *  @return pointer to G4VModularPhysicsList
    */
-  virtual G4VModularPhysicsList* physicsList();
+  G4VModularPhysicsList* physicsList() override;
 };
 
 #endif /* TESTGEOMETRY_G4TESTPHYSICSLIST_H */

--- a/Test/TestReconstruction/CMakeLists.txt
+++ b/Test/TestReconstruction/CMakeLists.txt
@@ -7,6 +7,10 @@ gaudi_depends_on_subdirs(GaudiAlg GaudiKernel FWCore Detector/DetInterface Detec
 find_package(Geant4)
 include(${Geant4_USE_FILE})
 
+find_package(DD4hep)
+find_package(ROOT)
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 gaudi_add_module(TestTestPlugins
                  src/*.cpp
                  INCLUDE_DIRS FWCore DetInterface Geant4 DetCommon DetSegmentation GaudiKernel

--- a/Test/TestReconstruction/src/TestCellCounting.h
+++ b/Test/TestReconstruction/src/TestCellCounting.h
@@ -25,15 +25,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  StatusCode execute() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
 private:
   /// Pointer to the geometry service

--- a/Test/TestReconstruction/src/TestNeighbours.h
+++ b/Test/TestReconstruction/src/TestNeighbours.h
@@ -36,15 +36,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() override final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute() final;
+  StatusCode execute() override final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() override final;
 
 private:
   /// Pointer to the geometry service

--- a/Visualization/CMakeLists.txt
+++ b/Visualization/CMakeLists.txt
@@ -7,12 +7,13 @@ gaudi_subdir(Visualization v1r0)
 gaudi_depends_on_subdirs(GaudiAlg FWCore)
 
 find_package(ROOT COMPONENTS Geom MathCore RIO Eve GenVector Gui REQUIRED)
-
-
-set(CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}  ${DD4hep_ROOT}/cmake )
+set(CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH} ${DD4hep_ROOT}/cmake )
 find_package(DD4hep COMPONENTS DDCore DDG4 DDEve REQUIRED)
 
 include(DD4hep)
+
+include_directories(SYSTEM ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
 
 find_package(FCCEDM)
 find_package(PODIO)

--- a/Visualization/src/FCCEventHandler.h
+++ b/Visualization/src/FCCEventHandler.h
@@ -28,25 +28,25 @@ public:
   virtual ~FCCEventHandler();
 
   /// Access the map of simulation data collections
-  virtual const TypedEventCollections& data() const override { return m_data; }
+  const TypedEventCollections& data() const override { return m_data; }
   /// Access the data source name
-  std::string datasourceName() const { return hasFile() ? m_fileName : std::string("UNKNOWN"); }
+  std::string datasourceName() const override { return hasFile() ? m_fileName : std::string("UNKNOWN"); }
   /// Access the number of events on the current input data source (-1 if no data source connected)
-  virtual long numEvents() const;
+  long numEvents() const override;
   /// Access to the collection type by name
-  virtual CollectionType collectionType(const std::string& collection) const;
+  CollectionType collectionType(const std::string& collection) const override;
   /// Call functor on hit collection
-  virtual size_t collectionLoop(const std::string& collection, DD4hep::DDEveHitActor& actor);
+  size_t collectionLoop(const std::string& collection, DD4hep::DDEveHitActor& actor) override;
   /// Loop over collection and extract particle data
-  virtual size_t collectionLoop(const std::string& collection, DD4hep::DDEveParticleActor& actor);
+  size_t collectionLoop(const std::string& collection, DD4hep::DDEveParticleActor& actor) override;
   /// Open new data file
-  virtual bool Open(const std::string& type, const std::string& file_name);
+  bool Open(const std::string& type, const std::string& file_name) override;
   /// User overloadable function: Load the next event
-  virtual bool NextEvent();
+  bool NextEvent() override;
   /// User overloadable function: Load the previous event
-  virtual bool PreviousEvent();
+  bool PreviousEvent() override;
   /// Goto a specified event in the file
-  virtual bool GotoEvent(long event_number);
+  bool GotoEvent(long event_number) override;
 };
 
 } /* End namespace vis   */

--- a/cmake/GaudiBuildFlags.cmake
+++ b/cmake/GaudiBuildFlags.cmake
@@ -92,6 +92,10 @@ option(GAUDI_V22
        "enable some API extensions"
        OFF)
 
+if (BINARY_TAG_COMP_NAME STREQUAL "gcc" AND BINARY_TAG_COMP_VERSION VERSION_GREATER "5.0")
+  option(GAUDI_SUGGEST_OVERRIDE "enable warnings for missing override keyword" ON)
+endif()
+
 
 string(COMPARE EQUAL "${BINARY_TAG_TYPE}" "do0" GAUDI_SLOW_DEBUG_DEFAULT)
 option(GAUDI_SLOW_DEBUG
@@ -192,7 +196,7 @@ if(NOT GAUDI_FLAGS_SET)
     endforeach()
     # Common compilation flags
     set(CMAKE_CXX_FLAGS
-        "${arch_opts} -fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -Wwrite-strings -Wpointer-arith -Woverloaded-virtual -Wno-long-long"
+        "${arch_opts} -fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -Wwrite-strings -Wpointer-arith -Woverloaded-virtual -Wno-long-long -Wno-shadow"
         CACHE STRING "Flags used by the compiler during all build types."
         FORCE)
     set(CMAKE_C_FLAGS

--- a/cmake/GaudiBuildFlags.cmake
+++ b/cmake/GaudiBuildFlags.cmake
@@ -1,9 +1,75 @@
+# parse binary tag
+include(BinaryTagUtils)
+if(NOT BINARY_TAG_COMP)
+  parse_binary_tag()
+endif()
+if(NOT HOST_BINARY_TAG_ARCH)
+  get_host_binary_tag(HOST_BINARY_TAG)
+  parse_binary_tag(HOST_BINARY_TAG)
+endif()
+
+check_compiler()
+
+
+# Convert BINARY_TAG_TYPE to CMAKE_BUILD_TYPE
+if(BINARY_TAG_TYPE STREQUAL "opt")
+  set(_BT_CMAKE_BUILD_TYPE Release)
+elseif(BINARY_TAG_TYPE MATCHES "^dbg|do0$")
+  set(_BT_CMAKE_BUILD_TYPE Debug)
+elseif(BINARY_TAG_TYPE STREQUAL "cov")
+  set(_BT_CMAKE_BUILD_TYPE Coverage)
+elseif(BINARY_TAG_TYPE STREQUAL "pro")
+  set(_BT_CMAKE_BUILD_TYPE Profile)
+#elseif(BINARY_TAG_TYPE STREQUAL "o2g")
+#  set(CMAKE_BUILD_TYPE RelWithDebInfo)
+#elseif(BINARY_TAG_TYPE STREQUAL "min")
+#  set(CMAKE_BUILD_TYPE MinSizeRel)
+else()
+  message(FATAL_ERROR "BINARY_TAG build type ${BINARY_TAG_TYPE} not supported.")
+endif()
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE ${_BT_CMAKE_BUILD_TYPE} CACHE STRING
+      "Choose the type of build, options are: Release, Debug, Coverage, Profile, RelWithDebInfo, MinSizeRel."
+      FORCE)
+else()
+  if(NOT _BT_CMAKE_BUILD_TYPE STREQUAL CMAKE_BUILD_TYPE)
+    message(WARNING "CMAKE_BUILD_TYPE set to ${CMAKE_BUILD_TYPE}, but BINARY_TAG build type ${BINARY_TAG_TYPE} implies ${_BT_CMAKE_BUILD_TYPE}")
+  endif()
+endif()
+
+
+# Report the platform ids.
+message(STATUS "Target system:    ${BINARY_TAG}")
+message(STATUS "CMake build type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "Host system:      ${HOST_BINARY_TAG}")
+message(STATUS "LCG system:       ${LCG_SYSTEM}")
+
+
 # define a minimun default version
 set(GAUDI_CXX_STANDARD_DEFAULT "c++14")
 # overriddend depending on the compiler
-
+if (BINARY_TAG_COMP_NAME STREQUAL "clang" AND BINARY_TAG_COMP_VERSION VERSION_GREATER "3.6")
+  set(GAUDI_CXX_STANDARD_DEFAULT "c++14")
+elseif(BINARY_TAG_COMP_NAME STREQUAL "gcc")
+  # Special defaults
+  if (BINARY_TAG_COMP_VERSION VERSION_LESS "4.7")
+    set(GAUDI_CXX_STANDARD_DEFAULT "c++98")
+  elseif(BINARY_TAG_COMP_VERSION VERSION_LESS "4.9")
+    # C++11 is enable by default on 4.7 <= gcc < 4.9
+    set(GAUDI_CXX_STANDARD_DEFAULT "c++11")
+  elseif(BINARY_TAG_COMP_VERSION VERSION_LESS "5.1")
+    # C++1y (C++14 preview) is enable by default on 4.9 <= gcc < 5.1
+    set(GAUDI_CXX_STANDARD_DEFAULT "c++1y")
+  else()
+    # C++14 is enable by default on gcc >= 5.1
+    set(GAUDI_CXX_STANDARD_DEFAULT "c++14")
+    option(GAUDI_GCC_OLD_ABI "use old gcc ABI for c++11 and above (gcc >= 5.1)"
+           OFF)
+  endif()
+endif()
 # special for GaudiHive
 set(GAUDI_CPP11_DEFAULT ON)
+
 #--- Gaudi Build Options -------------------------------------------------------
 # Build options that map to compile time features
 #
@@ -16,9 +82,6 @@ option(G21_HIDE_SYMBOLS
 option(G21_NEW_INTERFACES
        "disable backward-compatibility hacks in IInterface and InterfaceID"
        OFF)
-option(G21_NO_ENDREQ
-       "disable the 'endreq' stream modifier (use 'endmsg' instead)"
-       OFF)
 option(G21_NO_DEPRECATED
        "remove deprecated methods and functions"
        OFF)
@@ -29,23 +92,67 @@ option(GAUDI_V22
        "enable some API extensions"
        OFF)
 
-option(GAUDI_CMT_RELEASE
-       "use CMT deafult release flags instead of the CMake ones"
-       ON)
 
-if (LCG_COMP STREQUAL "gcc" AND LCG_COMPVERS VERSION_GREATER "50")
-  option(GAUDI_SUGGEST_OVERRIDE "enable warnings for missing override keyword" ON)
-endif()
-
-
-if(BINARY_TAG MATCHES "-do0$")
-  set(GAUDI_SLOW_DEBUG_DEFAULT ON)
-else()
-  set(GAUDI_SLOW_DEBUG_DEFAULT OFF)
-endif()
+string(COMPARE EQUAL "${BINARY_TAG_TYPE}" "do0" GAUDI_SLOW_DEBUG_DEFAULT)
 option(GAUDI_SLOW_DEBUG
        "turn off all optimizations in debug builds"
        ${GAUDI_SLOW_DEBUG_DEFAULT})
+
+# set optimization flags
+string(TOUPPER "${CMAKE_BUILD_TYPE}" _up_bt)
+foreach(_subtype ${BINARY_TAG_SUBTYPE})
+  if(_subtype MATCHES "^[oO]([0-3sg]|fast)$")
+    set(_opt_level_${_up_bt} "${_opt_level_${_up_bt}} -O${CMAKE_MATCH_1}")
+    #message(STATUS "setting _opt_level_${_up_bt} -> ${_opt_level_${_up_bt}}")
+  elseif(_subtype STREQUAL "g")
+    set(_opt_level_${_up_bt} "${_opt_level_${_up_bt}} -g")
+  endif()
+endforeach()
+
+if(_opt_level_RELWITHDEBINFO)
+  # RelWithDebInfo shared the flags with Release
+  set(_opt_level_RELEASE "${_opt_level_RELWITHDEBINFO}")
+endif()
+
+# default optimization levels
+if(NOT _opt_level_RELEASE)
+  set(_opt_level_RELEASE "-O3")
+  # RelWithDebInfo shared the flags with Release
+  set(_opt_level_RELWITHDEBINFO "${_opt_level_RELEASE}")
+endif()
+if(NOT _opt_level_DEBUG)
+  if(NOT GAUDI_SLOW_DEBUG AND
+     (BINARY_TAG_COMP_NAME STREQUAL "gcc" AND NOT BINARY_TAG_COMP_VERSION VERSION_LESS "4.8"))
+    # Use -Og with Debug builds in gcc >= 4.8 (if not disabled)
+    set(_opt_level_DEBUG "-Og")
+  else()
+    set(_opt_level_DEBUG "-O0")
+  endif()
+endif()
+
+if(_opt_level_${_up_bt})
+  message(STATUS "Optimization:     ${_opt_level_${_up_bt}}")
+endif()
+
+# special architecture flags
+set(GAUDI_ARCH_DEFAULT)
+if(BINARY_TAG_MICROARCH)
+  set(GAUDI_ARCH_DEFAULT ${BINARY_TAG_MICROARCH})
+elseif(BINARY_TAG_COMP_NAME STREQUAL "gcc" AND BINARY_TAG_COMP_VERSION VERSION_GREATER "5.0" AND
+   BINARY_TAG_ARCH STREQUAL "x86_64")
+  set(GAUDI_ARCH_DEFAULT "sse4.2")
+else()
+  if (NOT HOST_BINARY_TAG_ARCH STREQUAL BINARY_TAG_ARCH)
+    if (HOST_BINARY_TAG_ARCH STREQUAL "x86_64" AND BINARY_TAG_ARCH STREQUAL "i686")
+      set(GAUDI_ARCH_DEFAULT "32")
+    else()
+      message(FATAL_ERROR "Cannot build for ${BINARY_TAG_ARCH} on ${HOST_BINARY_TAG_ARCH}.")
+    endif()
+  endif()
+endif()
+set(GAUDI_ARCH "${GAUDI_ARCH_DEFAULT}"
+    CACHE STRING "Which architecture-specific optimizations to use")
+
 
 if(DEFINED GAUDI_CPP11)
   message(WARNING "GAUDI_CPP11 is an obsolete option, use GAUDI_CXX_STANDARD=c++11 instead")
@@ -56,7 +163,7 @@ set(GAUDI_CXX_STANDARD "${GAUDI_CXX_STANDARD_DEFAULT}"
 
 # If modern c++ and gcc >= 5.1 and requested, use old ABI compatibility
 if((NOT GAUDI_CXX_STANDARD STREQUAL "c++98") AND
-   (LCG_COMP STREQUAL "gcc" AND NOT LCG_COMPVERS VERSION_LESS "51") AND
+   (BINARY_TAG_COMP_NAME STREQUAL "gcc" AND NOT BINARY_TAG_COMP_VERSION VERSION_LESS "5.1") AND
    GAUDI_GCC_OLD_ABI)
   add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 endif()
@@ -74,71 +181,64 @@ if(NOT GAUDI_FLAGS_SET)
         CACHE STRING "Flags used by the compiler during debug builds."
         FORCE)
 
-    if(GAUDI_CMT_RELEASE)
-      set(CMAKE_CXX_FLAGS_RELEASE "/O2"
-          CACHE STRING "Flags used by the compiler during release builds."
-          FORCE)
-      set(CMAKE_C_FLAGS_RELEASE "/O2"
-          CACHE STRING "Flags used by the compiler during release builds."
-          FORCE)
-    endif()
-
   else()
-
+    # special architecture flags
+    set(arch_opts)
+    foreach(_arch_opt ${GAUDI_ARCH})
+      if(_arch_opt STREQUAL "native")
+        set(_arch_opt "arch=native")
+      endif()
+      set(arch_opts "${arch_opts} -m${_arch_opt}")
+    endforeach()
     # Common compilation flags
     set(CMAKE_CXX_FLAGS
-        "-fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -Wwrite-strings -Wpointer-arith -Woverloaded-virtual -Wno-long-long -Wno-shadow"
+        "${arch_opts} -fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -Wwrite-strings -Wpointer-arith -Woverloaded-virtual -Wno-long-long"
         CACHE STRING "Flags used by the compiler during all build types."
         FORCE)
     set(CMAKE_C_FLAGS
-        "-fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -Wwrite-strings -Wpointer-arith -Wno-long-long"
+        "${arch_opts} -fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -Wwrite-strings -Wpointer-arith -Wno-long-long"
         CACHE STRING "Flags used by the compiler during all build types."
         FORCE)
     set(CMAKE_Fortran_FLAGS
-        "-fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -fsecond-underscore"
+        "${arch_opts} -fmessage-length=0 -pipe -Wall -Wextra -Werror=return-type -pthread -pedantic -fsecond-underscore"
         CACHE STRING "Flags used by the compiler during all build types."
         FORCE)
 
-    if (LCG_COMP STREQUAL "gcc" AND LCG_COMPVERS VERSION_GREATER "50" AND GAUDI_SUGGEST_OVERRIDE)
+    if (BINARY_TAG_COMP_NAME STREQUAL "gcc" AND BINARY_TAG_COMP_VERSION VERSION_GREATER "5.0" AND GAUDI_SUGGEST_OVERRIDE)
         set(CMAKE_CXX_FLAGS
             "${CMAKE_CXX_FLAGS} -Wsuggest-override"
             CACHE STRING "Flags used by the compiler during all build types."
             FORCE)
     endif()
 
-    # Build type compilation flags (if different from default or uknown to CMake)
-    if(GAUDI_CMT_RELEASE)
-      set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG"
-          CACHE STRING "Flags used by the compiler during release builds."
-          FORCE)
-      set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG"
-          CACHE STRING "Flags used by the compiler during release builds."
-          FORCE)
-      set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -DNDEBUG"
-          CACHE STRING "Flags used by the compiler during release builds."
-          FORCE)
-    endif()
+    # Build type compilation flags
+    set(CMAKE_CXX_FLAGS_RELEASE "${_opt_level_RELEASE} -DNDEBUG"
+        CACHE STRING "Flags used by the compiler during release builds."
+        FORCE)
+    set(CMAKE_C_FLAGS_RELEASE "${_opt_level_RELEASE} -DNDEBUG"
+        CACHE STRING "Flags used by the compiler during release builds."
+        FORCE)
+    set(CMAKE_Fortran_FLAGS_RELEASE "${_opt_level_RELEASE} -DNDEBUG"
+        CACHE STRING "Flags used by the compiler during release builds."
+        FORCE)
 
-    if (LCG_COMP STREQUAL "gcc" AND LCG_COMPVERS VERSION_GREATER "47")
-      # Use -Og with Debug builds in gcc >= 4.8
-      set(CMAKE_CXX_FLAGS_DEBUG "-Og -g"
-          CACHE STRING "Flags used by the compiler during Debug builds."
-          FORCE)
-      set(CMAKE_C_FLAGS_DEBUG "-Og -g"
-          CACHE STRING "Flags used by the compiler during Debug builds."
-          FORCE)
-      set(CMAKE_Fortran_FLAGS_DEBUG "-Og -g"
-          CACHE STRING "Flags used by the compiler during Debug builds."
-          FORCE)
-    endif()
+    set(CMAKE_CXX_FLAGS_DEBUG "${_opt_level_DEBUG} -g"
+        CACHE STRING "Flags used by the compiler during Debug builds."
+        FORCE)
+    set(CMAKE_C_FLAGS_DEBUG "${_opt_level_DEBUG} -g"
+        CACHE STRING "Flags used by the compiler during Debug builds."
+        FORCE)
+    set(CMAKE_Fortran_FLAGS_DEBUG "${_opt_level_DEBUG} -g"
+        CACHE STRING "Flags used by the compiler during Debug builds."
+        FORCE)
 
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG"
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} -g"
         CACHE STRING "Flags used by the compiler during Release with Debug Info builds."
         FORCE)
-    set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG"
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELEASE} -g"
         CACHE STRING "Flags used by the compiler during Release with Debug Info builds."
         FORCE)
-    set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG"
+    set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELEASE} -g"
         CACHE STRING "Flags used by the compiler during Release with Debug Info builds."
         FORCE)
 
@@ -221,7 +321,8 @@ if(APPLE)
 endif()
 
 #--- Special build flags -------------------------------------------------------
-if ((GAUDI_V21 OR G21_HIDE_SYMBOLS) AND (LCG_COMP STREQUAL gcc AND LCG_COMPVERS MATCHES "4[0-9]"))
+if ((GAUDI_V21 OR G21_HIDE_SYMBOLS) AND (BINARY_TAG_COMP_NAME STREQUAL "gcc" AND
+                                         NOT BINARY_TAG_COMP_VERSION VERSION_LESS "4.0"))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
 endif()
 
@@ -239,7 +340,7 @@ else()
   endif()
 endif()
 
-if(LCG_COMP STREQUAL clang AND LCG_COMPVERS MATCHES "37")
+if(BINARY_TAG_COMP_NAME STREQUAL "clang" AND BINARY_TAG_COMP_VERSION VERSION_EQUAL "3.7")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${lcg_system_compiler_path}")
 endif()
 
@@ -250,49 +351,32 @@ if(NOT GAUDI_V21)
     add_definitions(-DGAUDI_V20_COMPAT)
   endif()
   # special case
-  if(G21_HIDE_SYMBOLS AND (LCG_COMP STREQUAL gcc AND LCG_COMPVERS MATCHES "^4"))
+  if(G21_HIDE_SYMBOLS AND (BINARY_TAG_COMP_NAME STREQUAL "gcc" AND
+                           NOT BINARY_TAG_COMP_VERSION VERSION_LESS "4.0"))
     add_definitions(-DG21_HIDE_SYMBOLS)
   endif()
   #
-  foreach (feature G21_NEW_INTERFACES G21_NO_ENDREQ G21_NO_DEPRECATED G22_NEW_SVCLOCATOR)
+  foreach (feature G21_NEW_INTERFACES G21_NO_DEPRECATED G22_NEW_SVCLOCATOR)
     if (${feature})
       add_definitions(-D${feature})
     endif()
   endforeach()
 endif()
 
-if (LCG_HOST_ARCH AND LCG_ARCH)
-  # this is valid only in the LCG toolchain context
-  if (LCG_HOST_ARCH STREQUAL x86_64 AND LCG_ARCH STREQUAL i686)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m32")
-    set(GCCXML_CXX_FLAGS "${GCCXML_CXX_FLAGS} -m32")
-  elseif(NOT LCG_HOST_ARCH STREQUAL LCG_ARCH)
-    message(FATAL_ERROR "Cannot build for ${LCG_ARCH} on ${LCG_HOST_ARCH}.")
-  endif()
-endif()
-
 #--- Tuning of warnings --------------------------------------------------------
 if(GAUDI_HIDE_WARNINGS)
-  if(LCG_COMP MATCHES clang)
+  if(BINARY_TAG_COMP_NAME STREQUAL "clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -Wno-deprecated -Wno-overloaded-virtual -Wno-char-subscripts -Wno-unused-parameter -Wno-unused-local-typedefs -Wno-missing-braces")
   else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wno-empty-body")
-    if(LCG_COMPVERS VERSION_GREATER "47")
+    if(BINARY_TAG_COMP_VERSION VERSION_GREATER "4.7")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
     endif()
   endif()
 else()
-  if(LCG_COMP STREQUAL gcc AND NOT LCG_COMPVERS VERSION_LESS "50")
+  if(BINARY_TAG_COMP_NAME STREQUAL "gcc" AND NOT BINARY_TAG_COMP_VERSION VERSION_LESS "5.0")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
   endif()
-endif()
-
-if(GAUDI_SLOW_DEBUG)
-  string(REPLACE "-Og" "-O0" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-  string(REPLACE "-Og" "-O0" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-  string(REPLACE "-Og" "-O0" CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}")
 endif()
 
 #--- Special flags -------------------------------------------------------------
@@ -303,11 +387,7 @@ add_definitions(-DBOOST_FILESYSTEM_VERSION=3)
 #        and http://stackoverflow.com/a/20440238/504346
 add_definitions(-DBOOST_SPIRIT_USE_PHOENIX_V3)
 
-if((LCG_COMP STREQUAL gcc AND LCG_COMPVERS MATCHES "47|max") OR GAUDI_CPP11)
-  set(GCCXML_CXX_FLAGS "${GCCXML_CXX_FLAGS} -D__STRICT_ANSI__")
-endif()
-
-if(LCG_COMP STREQUAL gcc AND LCG_COMPVERS STREQUAL 43)
+if(BINARY_TAG_COMP_NAME STREQUAL "gcc" AND BINARY_TAG_COMP_VERSION VERSION_EQUAL "4.3")
   # The -pedantic flag gives problems on GCC 4.3.
   string(REPLACE "-pedantic" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   string(REPLACE "-pedantic" "" CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}")


### PR DESCRIPTION
With gcc6.2 we have several warnings popping up where externals are using deprecated STL functionality. Furthermore, warnings exist that help making use of C++1y features that couldn't be used because they lead to many such warnings from the externals. This PR implements a workaround.

Changes proposed in this pull-request:

- Update build flags to the latest version in Gaudi (still need to override to -Wno-shadow due to many warnings from Gaudi itself)
- Include headers from externals as `SYSTEM` (the compiler does not parse them for warnings, errors, etc)
- Add override statements throughout FCCSW where appropriate
- Switch to ninja as default build tool