### PR TITLE
Interactive mode

### DIFF
--- a/Examples/options/interactive_mode.py
+++ b/Examples/options/interactive_mode.py
@@ -1,0 +1,30 @@
+"""
+nalipour@cern.ch
+Activate the Geant4 interactive mode and use the Geant4 console. By default, the interactive mode is deactivated
+"""
+
+from Gaudi.Configuration import *
+
+# DD4hep geometry service
+# Parses the given xml file
+from Configurables import GeoSvc
+geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+                                         'file:Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml'
+                                         ],
+                    OutputLevel = DEBUG)
+
+# Geant4 service
+# Configures the Geant simulation: geometry, physics list and user actions
+from Configurables import SimG4Svc
+# giving the names of tools will initialize the tools of that type
+geantservice = SimG4Svc("SimG4Svc", detector='SimG4DD4hepDetector', physicslist="SimG4FtfpBert", actions="SimG4FullSimActions", InteractiveMode="true")
+
+
+from Configurables import ApplicationMgr
+ApplicationMgr( TopAlg = [],
+                EvtSel = 'NONE',
+                EvtMax   = 1,
+                # order is important, as GeoSvc is needed by SimG4Svc
+                ExtSvc = [geoservice, geantservice],
+                OutputLevel=DEBUG
+ )

--- a/Sim/SimG4Components/src/SimG4Svc.cpp
+++ b/Sim/SimG4Components/src/SimG4Svc.cpp
@@ -66,8 +66,11 @@ StatusCode SimG4Svc::initialize() {
   m_runManager.Initialize();
 
   if (m_interactiveMode) {
-    visManager->Initialize();
-    session->SessionStart();
+    m_visManager = std::make_unique<G4VisExecutive>();
+    m_visManager->Initialize();
+
+    m_session = std::make_unique<G4UIterminal>();
+    m_session->SessionStart();
   }
 
   // Attach user actions

--- a/Sim/SimG4Components/src/SimG4Svc.cpp
+++ b/Sim/SimG4Components/src/SimG4Svc.cpp
@@ -65,12 +65,8 @@ StatusCode SimG4Svc::initialize() {
 
   m_runManager.Initialize();
 
-  std::unique_ptr<G4VisManager> visManager(new G4VisExecutive);
-
   if (m_interactiveMode) {
     visManager->Initialize();
-    // Define UI terminal for interactive mode
-    std::unique_ptr<G4UIsession> session(new G4UIterminal());
     session->SessionStart();
   }
 

--- a/Sim/SimG4Components/src/SimG4Svc.cpp
+++ b/Sim/SimG4Components/src/SimG4Svc.cpp
@@ -8,6 +8,11 @@
 #include "G4UImanager.hh"
 #include "G4VModularPhysicsList.hh"
 
+#include "G4UIsession.hh"
+#include "G4UIterminal.hh"
+#include "G4VisExecutive.hh"
+#include "G4VisManager.hh"
+
 DECLARE_SERVICE_FACTORY(SimG4Svc)
 
 SimG4Svc::SimG4Svc(const std::string& aName, ISvcLocator* aSL) : base_class(aName, aSL) {
@@ -54,12 +59,20 @@ StatusCode SimG4Svc::initialize() {
   m_runManager.SetUserInitialization(m_detectorTool->detectorConstruction());
 
   G4UImanager* UImanager = G4UImanager::GetUIpointer();
-  for (auto command: m_g4PreInitCommands) {
+  for (auto command : m_g4PreInitCommands) {
     UImanager->ApplyCommand(command);
   }
 
-
   m_runManager.Initialize();
+  if (m_interactiveMode) {
+    G4VisManager* visManager = new G4VisExecutive;
+    visManager->Initialize();
+    // Define UI terminal for interactive mode
+    G4UIsession* session = new G4UIterminal;
+    session->SessionStart();
+    delete session;
+  }
+
   // Attach user actions
   m_runManager.SetUserInitialization(m_actionsTool->userActionInitialization());
   // Create regions
@@ -74,7 +87,7 @@ StatusCode SimG4Svc::initialize() {
   for (auto& tool : m_regionTools) {
     tool->create();
   }
- for (auto command: m_g4PostInitCommands) {
+  for (auto command : m_g4PostInitCommands) {
     UImanager->ApplyCommand(command);
   }
 

--- a/Sim/SimG4Components/src/SimG4Svc.cpp
+++ b/Sim/SimG4Components/src/SimG4Svc.cpp
@@ -64,13 +64,14 @@ StatusCode SimG4Svc::initialize() {
   }
 
   m_runManager.Initialize();
+
+  std::unique_ptr<G4VisManager> visManager(new G4VisExecutive);
+
   if (m_interactiveMode) {
-    G4VisManager* visManager = new G4VisExecutive;
     visManager->Initialize();
     // Define UI terminal for interactive mode
-    G4UIsession* session = new G4UIterminal;
+    std::unique_ptr<G4UIsession> session(new G4UIterminal());
     session->SessionStart();
-    delete session;
   }
 
   // Attach user actions

--- a/Sim/SimG4Components/src/SimG4Svc.h
+++ b/Sim/SimG4Components/src/SimG4Svc.h
@@ -14,6 +14,11 @@
 #include "GaudiKernel/Service.h"
 #include "GaudiKernel/ToolHandle.h"
 
+#include "G4UIsession.hh"
+#include "G4UIterminal.hh"
+#include "G4VisExecutive.hh"
+#include "G4VisManager.hh"
+
 /** @class SimG4Svc SimG4Components/SimG4Components/SimG4Svc.h SimG4Svc.h
  *
  *  Main Geant simulation service.
@@ -83,6 +88,10 @@ private:
 
   /// Run Manager
   sim::RunManager m_runManager;
+
+  std::unique_ptr<G4VisManager> visManager = std::make_unique<G4VisExecutive>();
+  // Define UI terminal for interactive mode
+  std::unique_ptr<G4UIsession> session = std::make_unique<G4UIterminal>();
 };
 
 #endif /* SIMG4COMPONENTS_G4SIMSVC_H */

--- a/Sim/SimG4Components/src/SimG4Svc.h
+++ b/Sim/SimG4Components/src/SimG4Svc.h
@@ -89,9 +89,9 @@ private:
   /// Run Manager
   sim::RunManager m_runManager;
 
-  std::unique_ptr<G4VisManager> visManager = std::make_unique<G4VisExecutive>();
+  std::unique_ptr<G4VisManager> m_visManager{nullptr};
   // Define UI terminal for interactive mode
-  std::unique_ptr<G4UIsession> session = std::make_unique<G4UIterminal>();
+  std::unique_ptr<G4UIsession> m_session{nullptr};
 };
 
 #endif /* SIMG4COMPONENTS_G4SIMSVC_H */

--- a/Sim/SimG4Components/src/SimG4Svc.h
+++ b/Sim/SimG4Components/src/SimG4Svc.h
@@ -66,9 +66,11 @@ private:
   /// Handle for the magnetic field initialization
   ToolHandle<ISimG4MagneticFieldTool> m_magneticFieldTool{"SimG4ConstantMagneticFieldTool", this, true};
   /// Geant4 commands to be executed before user initialization
-  Gaudi::Property<std::vector<std::string>> m_g4PreInitCommands{this, "g4PreInitCommands", {}, "Geant4 commands to be executed before user initialization"};
+  Gaudi::Property<std::vector<std::string>> m_g4PreInitCommands{
+      this, "g4PreInitCommands", {}, "Geant4 commands to be executed before user initialization"};
   /// Geant4 commands to be executed after user initialization
-  Gaudi::Property<std::vector<std::string>> m_g4PostInitCommands{this, "g4PostInitCommands", {}, "Geant4 commands to be executed after user initialization"};
+  Gaudi::Property<std::vector<std::string>> m_g4PostInitCommands{
+      this, "g4PostInitCommands", {}, "Geant4 commands to be executed after user initialization"};
   /// Handles to the tools creating regions and fast simulation models
   /// to be replaced with the ToolHandleArray<ISimG4RegionTool> m_regionTools
   std::vector<ISimG4RegionTool*> m_regionTools;

--- a/Sim/SimG4Components/src/SimG4Svc.h
+++ b/Sim/SimG4Components/src/SimG4Svc.h
@@ -77,6 +77,8 @@ private:
   Gaudi::Property<std::vector<std::string>> m_regionToolNames{
       this, "regions", {}, "Names of the tools that create regions and fast simulation models"};
 
+  Gaudi::Property<bool> m_interactiveMode{this, "InteractiveMode", false, "Enter the interactive mode"};
+
   /// Run Manager
   sim::RunManager m_runManager;
 };

--- a/Sim/doc/InteractiveMode.md
+++ b/Sim/doc/InteractiveMode.md
@@ -1,0 +1,22 @@
+Interactive mode driven by command lines of Geant4 in FCCSW
+==
+
+The interactive mode allows for FCCSW to run interactively, waiting for command lines enetered from keyboard.
+
+By running the script: 
+./run gaudirun.py Examples/options/interactive_mode.py
+
+the program will load the geometry and enters into the interactive mode waiting for commands to be entered, by setting InteractiveMode="true" in SimG4Svc.
+
+If the PATH has been correctly configured with the DAWN installation, the user by entering the commands here below, can visualise the geometry in DAWN:
+
+/vis/scene/create
+/vis/scene/add/volume
+/vis/scene/add/hits
+/vis/scene/add/trajectories
+/tracking/storeTrajectory 1
+/vis/open DAWNFILE
+/vis/geometry/set/forceSolid all -1 true
+/vis/drawVolume
+/vis/viewer/flush
+


### PR DESCRIPTION
Addresses # .

Changes proposed in this pull-request:

- SimG4Svc changed in order to run Geant4 in interactive mode and use the Geant4 command lines in the terminal. It is useful for debugging but especially for the execution of DAWN visualisation.
- An example of script for running FCCSW in interactive mode: Examples/options/interactive_mode.py
