### PR TITLE
Save Geant TrackIDs with hits

### DIFF
--- a/FWCore/src/components/PileupHitMergeTool.cpp
+++ b/FWCore/src/components/PileupHitMergeTool.cpp
@@ -82,11 +82,15 @@ StatusCode PileupHitMergeTool<Hits, PositionedHits>::mergeCollections() {
   Hits* collHitsMerged = new Hits();
   PositionedHits* collPosHitsMerged = new PositionedHits();
 
+  unsigned int collectionCounter = 0;
   for (auto hitColl : m_hitCollections) {
     // copy hits
     for (const auto elem : *hitColl) {
+      auto clon = elem.clone()
+      clon.bits += collectionCounter * 2 << 32; // add pileup vertex counter with an offset
       collHitsMerged->push_back(elem.clone());
     }
+    ++collectionCounter;
   }
   for (auto posHitColl : m_posHitCollections) {
     // copy positioned hits

--- a/FWCore/src/components/PileupHitMergeTool.cpp
+++ b/FWCore/src/components/PileupHitMergeTool.cpp
@@ -86,8 +86,19 @@ StatusCode PileupHitMergeTool<Hits, PositionedHits>::mergeCollections() {
   for (auto hitColl : m_hitCollections) {
     // copy hits
     for (const auto elem : *hitColl) {
+
       auto clon = elem.clone();
-      clon.bits(clon.bits() + collectionCounter * (2 << 20)); // add pileup vertex counter with an offset
+      // add pileup vertex counter with an offset
+      // i.e. for the signal event, 'bits' is just the trackID taken from geant
+      // for the n-th pileup event, 'bits' is the trackID + n * offset
+      // offset needs to be big enough to ensure uniqueness of trackID
+      if (elem.bits() > m_trackIDCollectionOffset) {
+        error() << "Event contains too many tracks to guarantee a unique trackID";
+        error() << " The offset width or trackID field size needs to be adjusted!" << endmsg;
+        return StatusCode::FAILURE;
+      }
+
+      clon.bits(clon.bits() + collectionCounter * m_trackIDCollectionOffset);
       collHitsMerged->push_back(clon);
     }
     ++collectionCounter;

--- a/FWCore/src/components/PileupHitMergeTool.cpp
+++ b/FWCore/src/components/PileupHitMergeTool.cpp
@@ -86,9 +86,9 @@ StatusCode PileupHitMergeTool<Hits, PositionedHits>::mergeCollections() {
   for (auto hitColl : m_hitCollections) {
     // copy hits
     for (const auto elem : *hitColl) {
-      auto clon = elem.clone()
-      clon.bits += collectionCounter * 2 << 32; // add pileup vertex counter with an offset
-      collHitsMerged->push_back(elem.clone());
+      auto clon = elem.clone();
+      clon.bits(clon.bits() + collectionCounter * (2 << 20)); // add pileup vertex counter with an offset
+      collHitsMerged->push_back(clon);
     }
     ++collectionCounter;
   }

--- a/FWCore/src/components/PileupHitMergeTool.h
+++ b/FWCore/src/components/PileupHitMergeTool.h
@@ -16,6 +16,9 @@ class PositionedHitCollection;
 /** @class PileupHitMergeTool
  *
  * Implemenation of the MergeTool for *Hits and *PositionedHits, templated to give versions for Tracker / Calorimeter
+ * While merging, this algorithm tries to keep the trackIDs unique by adding the pileup event number with an offset.
+ * This should be transparent, but the trackIDs will be non-consecutive.
+ *
  *
  */
 
@@ -60,6 +63,9 @@ private:
   DataHandle<Hits> m_hitsSignal{"overlay/signalHits", Gaudi::DataHandle::Reader, this};
   /// input to this tool: signal collection
   DataHandle<PositionedHits> m_posHitsSignal{"overlay/signalPositionedHits", Gaudi::DataHandle::Reader, this};
+
+  /// offset with which the pileup event number is added to the trackID 
+  const unsigned int m_trackIDCollectionOffset = 2 << 20;
 };
 
 #endif  // FWCORE_PILEUPTRACKERHITSMERGETOOL_H

--- a/Sim/SimG4Components/src/SimG4SaveTrackerHits.cpp
+++ b/Sim/SimG4Components/src/SimG4SaveTrackerHits.cpp
@@ -70,6 +70,7 @@ StatusCode SimG4SaveTrackerHits::saveOutput(const G4Event& aEvent) {
           fcc::BareHit& edmHitCore = edmHit.core();
           edmHitCore.cellId = hit->cellID;
           edmHitCore.energy = hit->energyDeposit * sim::g42edm::energy;
+          edmHitCore.bits = hit->truth.trackID;
           edmHitCore.time = hit->truth.time;
           auto position = fcc::Point();
           position.x = hit->position.x() * sim::g42edm::length;


### PR DESCRIPTION

Changes proposed in this pull-request:

- Geant4 trackId saved with hit in `bits` field
- when merging pileup, an offset of `pileupVertexIndex * 2 **20` is added to the trackId to keep it unique 

