### PR TITLE
Update simple tracker sd

### DIFF
--- a/Detector/DetSensitive/src/SimpleTrackerSD.cpp
+++ b/Detector/DetSensitive/src/SimpleTrackerSD.cpp
@@ -38,8 +38,6 @@ bool SimpleTrackerSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   if (edep == 0.) return false;
   // get track
   const G4Track* track = aStep->GetTrack();
-  // check if particle is still alive - we do not want to write out a hit of a dead particle
-  if (track->GetTrackStatus() != fAlive) return false;
   // as in DD4hep::Simulation::Geant4GenericSD<Tracker>
   CLHEP::Hep3Vector prePos = aStep->GetPreStepPoint()->GetPosition();
   DD4hep::Simulation::Position position(prePos.x(), prePos.y(), prePos.z());

--- a/Detector/DetSensitive/src/SimpleTrackerSD.cpp
+++ b/Detector/DetSensitive/src/SimpleTrackerSD.cpp
@@ -42,9 +42,8 @@ bool SimpleTrackerSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   if (track->GetTrackStatus() != fAlive) return false;
   // as in DD4hep::Simulation::Geant4GenericSD<Tracker>
   CLHEP::Hep3Vector prePos = aStep->GetPreStepPoint()->GetPosition();
-  CLHEP::Hep3Vector postPos = aStep->GetPostStepPoint()->GetPosition();
   DD4hep::Simulation::Position position(prePos.x(), prePos.y(), prePos.z());
-  CLHEP::Hep3Vector direction = postPos - prePos;
+  CLHEP::Hep3Vector momentum = aStep->GetPreStepPoint()->GetMomentum();
   // create a hit and add it to collection
   // deleted in ~G4Event
   auto hit = new DD4hep::Simulation::Geant4TrackerHit(
@@ -52,7 +51,7 @@ bool SimpleTrackerSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   hit->cellID = utils::cellID(m_seg, *aStep);
   hit->energyDeposit = edep;
   hit->position = position;
-  hit->momentum = direction;
+  hit->momentum = momentum;
   m_trackerCollection->insert(hit);
   return true;
 }

--- a/Detector/DetSensitive/src/SimpleTrackerSD.cpp
+++ b/Detector/DetSensitive/src/SimpleTrackerSD.cpp
@@ -38,7 +38,7 @@ bool SimpleTrackerSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   if (edep == 0.) return false;
   // get track
   const G4Track* track = aStep->GetTrack();
-  // check track status
+  // check if particle is still alive - we do not want to write out a hit of a dead particle
   if (track->GetTrackStatus() != fAlive) return false;
   // as in DD4hep::Simulation::Geant4GenericSD<Tracker>
   CLHEP::Hep3Vector prePos = aStep->GetPreStepPoint()->GetPosition();

--- a/Detector/DetSensitive/src/SimpleTrackerSD.cpp
+++ b/Detector/DetSensitive/src/SimpleTrackerSD.cpp
@@ -36,14 +36,16 @@ bool SimpleTrackerSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   // check if energy was deposited
   G4double edep = aStep->GetTotalEnergyDeposit();
   if (edep == 0.) return false;
-
+  // get track
+  const G4Track* track = aStep->GetTrack();
+  // check track status
+  if (track->GetTrackStatus() != fAlive) return false;
   // as in DD4hep::Simulation::Geant4GenericSD<Tracker>
   CLHEP::Hep3Vector prePos = aStep->GetPreStepPoint()->GetPosition();
   CLHEP::Hep3Vector postPos = aStep->GetPostStepPoint()->GetPosition();
   DD4hep::Simulation::Position position(prePos.x(), prePos.y(), prePos.z());
   CLHEP::Hep3Vector direction = postPos - prePos;
   // create a hit and add it to collection
-  const G4Track* track = aStep->GetTrack();
   // deleted in ~G4Event
   auto hit = new DD4hep::Simulation::Geant4TrackerHit(
       track->GetTrackID(), track->GetDefinition()->GetPDGEncoding(), edep, track->GetGlobalTime());


### PR DESCRIPTION
Changes proposed in this pull-request:
Minor changes to SimpleTrackerSD
- at the moment the difference of the post step to the pre step point is set for the momentum. Now the momentum of the pre step point is used.
- Add a check if the track is still alive


