### PR TITLE
Update of endcap and forward calorimeters

### DIFF
--- a/Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml
+++ b/Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml
@@ -43,11 +43,11 @@
     <constant name="EMEC_rmin1" value="CryoEndcap_front_rmin2 + CryoThicknessInner + BathThicknessFront*tan(2*atan(exp(-2.5)))"/>
     <constant name="EMEC_rmin2" value="EMEC_z2*tan(2*atan(exp(-2.5))) - 10*cm + CryoThicknessInner"/>
     <constant name="EMEC_rmax" value="ExtBarCal_rmax - CryoThicknessOuter - BathThicknessOuter"/>
-    <constant name="EMEC_lAr_thickness" value="3.*mm"/>
-    <constant name="EMEC_Pb_thickness" value="1.5*mm*2./2.16"/>
-    <constant name="EMEC_steel_thickness" value="0.4*mm*2./2.16"/>
-    <constant name="EMEC_glue_thickness" value="0.26*mm*2./2.16"/>
-    <constant name="EMEC_readout_thickness" value="1*mm"/>
+    <constant name="EMEC_lAr_thickness" value="1.*mm"/>
+    <constant name="EMEC_Pb_thickness" value="1.5*mm*1.5/2.16"/>
+    <constant name="EMEC_steel_thickness" value="0.4*mm*1.5/2.16"/>
+    <constant name="EMEC_glue_thickness" value="0.26*mm*1.5/2.16"/>
+    <constant name="EMEC_readout_thickness" value="1.2*mm"/>
     <!-- hadronic calorimeter: HEC -->
     <constant name="HEC_z1" value="EMEC_z2 + BathThicknessMiddle"/>
     <constant name="HEC_z2" value="CryoEndcap_z2 - CryoThicknessBack - BathThicknessBack"/>
@@ -56,7 +56,7 @@
     <constant name="HEC_rmax" value="ExtBarCal_rmax - CryoThicknessOuter - BathThicknessOuter"/>
     <constant name="HEC_lAr_thickness" value="4.*mm"/>
     <constant name="HEC_Cu_thickness" value="2.*cm"/>
-    <constant name="HEC_readout_thickness" value="1*mm"/>
+    <constant name="HEC_readout_thickness" value="1.2*mm"/>
   </define>
   <readouts>
     <readout name="EMECPhiEta">

--- a/Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml
+++ b/Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml
@@ -42,8 +42,8 @@
     <constant name="EMFWD_rmin1" value="CryoFwd_front_rmin2 + CryoThicknessInner + BathThicknessFront*tan(2*atan(exp(-6)))"/>
     <constant name="EMFWD_rmin2" value="EMFWD_z2 * tan(2*atan(exp(-6)))"/>
     <constant name="EMFWD_rmax" value="FwdCal_rmax - CryoThicknessOuter - BathThicknessOuter"/>
-    <constant name="EMFWD_lAr_thickness" value="0.1*mm"/>
-    <constant name="EMFWD_Cu_thickness" value="3*cm"/>
+    <constant name="EMFWD_lAr_thickness" value="0.2*mm"/>
+    <constant name="EMFWD_Cu_thickness" value="1*cm"/>
     <constant name="EMFWD_readout_thickness" value="1.2*mm"/>
     <!-- hadronic calorimeter: HFWD -->
     <constant name="HFWD_z1" value="EMFWD_z2 + BathThicknessMiddle"/>
@@ -51,7 +51,7 @@
     <constant name="HFWD_rmin1" value="HFWD_z1*tan(2*atan(exp(-6)))"/>
     <constant name="HFWD_rmin2" value="CryoFwd_back_rmin1 + CryoThicknessInner - BathThicknessBack*tan(2*atan(exp(-6)))"/>
     <constant name="HFWD_rmax" value="FwdCal_rmax - CryoThicknessOuter - BathThicknessOuter"/>
-    <constant name="HFWD_lAr_thickness" value="0.1*mm"/>
+    <constant name="HFWD_lAr_thickness" value="0.2*mm"/>
     <constant name="HFWD_Cu_thickness" value="4.*cm"/>
     <constant name="HFWD_readout_thickness" value="1.2*mm"/>
   </define>

--- a/Detector/DetFCChhCalDiscs/src/CaloEndcapDiscs_geo.cpp
+++ b/Detector/DetFCChhCalDiscs/src/CaloEndcapDiscs_geo.cpp
@@ -7,7 +7,7 @@
 
 namespace det {
 void buildOneSide(MsgStream& lLog, DD4hep::Geometry::LCDD& aLcdd, DD4hep::Geometry::SensitiveDetector& aSensDet,
-                    DD4hep::Geometry::Volume& aEnvelope, DD4hep::XML::Handle_t& aXmlElement, int sign) {
+                  DD4hep::Geometry::Volume& aEnvelope, DD4hep::XML::Handle_t& aXmlElement, int sign) {
 
   DD4hep::XML::Dimension dim(aXmlElement.child(_Unicode(dimensions)));
 
@@ -54,7 +54,7 @@ void buildOneSide(MsgStream& lLog, DD4hep::Geometry::LCDD& aLcdd, DD4hep::Geomet
        << "\nThickness of absorber discs (cm) = " << passiveThickness
        << "\nThickness of readout disc placed in between absorber plates (cm) = " << readoutThickness
        << "\nNumber of absorber/readout discs: " << numDiscs
-    // + 1 to add the first active layer in between the first readout disc and the first absorber
+       // + 1 to add the first active layer in between the first readout disc and the first absorber
        << "\nNumber of active layers: " << numDiscs + 1
        << "\nMargin outside first readout disc and last absorber disc, filled with non-sensitive active medium (cm) = "
        << marginOutside << endmsg;
@@ -188,8 +188,8 @@ void buildOneSide(MsgStream& lLog, DD4hep::Geometry::LCDD& aLcdd, DD4hep::Geomet
 }
 
 static DD4hep::Geometry::Ref_t createCaloDiscs(DD4hep::Geometry::LCDD& aLcdd,
-                                                     DD4hep::XML::Handle_t aXmlElement,
-                                                     DD4hep::Geometry::SensitiveDetector aSensDet) {
+                                               DD4hep::XML::Handle_t aXmlElement,
+                                               DD4hep::Geometry::SensitiveDetector aSensDet) {
   ServiceHandle<IMessageSvc> msgSvc("MessageSvc", "CalDiscsConstruction");
   MsgStream lLog(&(*msgSvc), "CalDiscsConstruction");
 

--- a/Detector/DetFCChhCalDiscs/src/CaloEndcapDiscs_geo.cpp
+++ b/Detector/DetFCChhCalDiscs/src/CaloEndcapDiscs_geo.cpp
@@ -54,6 +54,8 @@ void buildOneSide(MsgStream& lLog, DD4hep::Geometry::LCDD& aLcdd, DD4hep::Geomet
        << "\nThickness of absorber discs (cm) = " << passiveThickness
        << "\nThickness of readout disc placed in between absorber plates (cm) = " << readoutThickness
        << "\nNumber of absorber/readout discs: " << numDiscs
+    // + 1 to add the first active layer in between the first readout disc and the first absorber
+       << "\nNumber of active layers: " << numDiscs + 1
        << "\nMargin outside first readout disc and last absorber disc, filled with non-sensitive active medium (cm) = "
        << marginOutside << endmsg;
   lLog << MSG::INFO << "Detector length: (cm) " << length << endmsg;


### PR DESCRIPTION
Changes proposed in this pull-request:

- decreasing the LAr gap in the endcap to 1mm
- matching thickness of PCB to the value in EM barrel (1.2mm)
- matching EM forward LAr/Cu ratio to the ratio of LAr/absorber of ATLAS detector