### PR TITLE
Set DD4hep print level from Gaudi msg level

### DIFF
--- a/Detector/DetComponents/src/GeoSvc.cpp
+++ b/Detector/DetComponents/src/GeoSvc.cpp
@@ -25,7 +25,7 @@ StatusCode GeoSvc::initialize() {
   StatusCode sc = Service::initialize();
   if (!sc.isSuccess()) return sc;
   uint printoutLevel = msgLevel();
-  DD4hep::setPrintoutLevel(DD4hep::PrintLevel(printoutLevel));
+  DD4hep::setPrintLevel(DD4hep::PrintLevel(printoutLevel));
   m_incidentSvc->addListener(this, "GeometryFailure");
   if (buildDD4HepGeo().isFailure())
     m_log << MSG::ERROR << "Could not build DD4Hep geometry" << endmsg;

--- a/Detector/DetComponents/src/GeoSvc.cpp
+++ b/Detector/DetComponents/src/GeoSvc.cpp
@@ -10,6 +10,8 @@
 #include "GaudiKernel/Service.h"
 #include "GeoConstruction.h"
 
+#include "DD4hep/Printout.h"
+
 using namespace Gaudi;
 
 DECLARE_COMPONENT(GeoSvc)
@@ -22,6 +24,8 @@ GeoSvc::~GeoSvc() { m_dd4hepgeo->destroyInstance(); }
 StatusCode GeoSvc::initialize() {
   StatusCode sc = Service::initialize();
   if (!sc.isSuccess()) return sc;
+  uint printoutLevel = msgLevel();
+  DD4hep::setPrintoutLevel(DD4hep::PrintLevel(printoutLevel));
   m_incidentSvc->addListener(this, "GeometryFailure");
   if (buildDD4HepGeo().isFailure())
     m_log << MSG::ERROR << "Could not build DD4Hep geometry" << endmsg;


### PR DESCRIPTION
Changes proposed in this pull-request:

- Set the print level of DD4hep to output level of Gaudi (GeoSvc). This allows getting rid of most of the DD4hep output if GeoSvc.OutputLevel = WARNING
