### PR TITLE
Switch Tracker beampipe for the centrally defined one

### DIFF
--- a/Detector/DetFCChhBaseline1/compact/FCChh_DectMaster.xml
+++ b/Detector/DetFCChhBaseline1/compact/FCChh_DectMaster.xml
@@ -26,9 +26,7 @@
   <include ref="./FCChh_Visualisation.xml" />
 
   <!-- Including the sub-detectors / volume definitions -->
-  <!-- To be used in case you are not using the tkLayout tracker (which contains the beamtube)
   <include ref="./FCChh_BeamTube.xml" />
-  -->
   <include ref="./FCChh_Solenoids.xml" />
   <include ref="./FCChh_Shielding.xml" />
 

--- a/Detector/DetFCChhBaseline1/compact/FCChh_DectMaster.xml
+++ b/Detector/DetFCChhBaseline1/compact/FCChh_DectMaster.xml
@@ -36,7 +36,7 @@
   <include ref="../../DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml" />
   <!-- To uncomment once issue #227 is solved: <include ref="../../DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml" /> -->
   <!-- To uncomment once issue #227 is solved: <include ref="../../DetFCChhCalDiscs/compact/Forward_coneCryo.xml" /> -->
-  <include ref="../../DetFCChhMuonSimple/compact/FCChh_MuonSystemSimple.xml" />
+  <!-- To uncomment once overlaps with beampipe are solved: <include ref="../../DetFCChhMuonSimple/compact/FCChh_MuonSystemSimple.xml" /> -->
 
   <!--
     These can be used as replacement if you want to use only a sub-set of detectors:

--- a/Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml
+++ b/Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml
@@ -15,9 +15,11 @@
     </readouts>
     <include ref="FCChh_v3.03_Definitions.xml"/>
     <detectors>
+        <!-- To be used if you are using ACTS (instead of the full beampipe in DectMaster
         <detector id="0" name="beampipe" type="BeamTube">
             <dimensions rmin="CentralBeamTube_rmin" rmax="CentralBeamTube_rmax" z="CentralBeamTube_dz" material="Beryllium" vis="violet"/>
         </detector>
+        -->
         <detector id="101" name="FCChhInner" type="DD4hep_SubdetectorAssembly" vis="BlueVisTrans">
             <composite name="InnerBRL"/>
             <composite name="InnerECAP"/>


### PR DESCRIPTION
The simulation plans require the full beampipe, instead of the one that was simplified for compatibility with ACTS. This should be harmonised with the update of the DD4hepPlugin