### PR TITLE
Tail catcher

### DIFF
--- a/Detector/DetFCChhBaseline1/compact/FCChh_DectDimensions.xml
+++ b/Detector/DetFCChhBaseline1/compact/FCChh_DectDimensions.xml
@@ -150,7 +150,7 @@
     <constant name="FwdBarMuon_zOffset" value="14000*mm + FwdBarMuon_dz"/>
 
     <constant name="FwdMuon_id" value="15"/>
-    <constant name="FwdMuon_rmin" value="30*mm"/>
+    <constant name="FwdMuon_rmin" value="62.3*mm"/>
     <constant name="FwdMuon_rmax" value="7000*mm"/>
     <constant name="FwdMuon_dz" value="1500*mm"/>
     <constant name="FwdMuon_zOffset" value="19700*mm + FwdMuon_dz"/> 

--- a/Detector/DetFCChhBaseline1/compact/FCChh_DectMaster.xml
+++ b/Detector/DetFCChhBaseline1/compact/FCChh_DectMaster.xml
@@ -38,7 +38,7 @@
   <include ref="../../DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml" />
   <!-- To uncomment once issue #227 is solved: <include ref="../../DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml" /> -->
   <!-- To uncomment once issue #227 is solved: <include ref="../../DetFCChhCalDiscs/compact/Forward_coneCryo.xml" /> -->
-  <include ref="../../DetFCChhMuonSimple/compact/FCChh_MuonSystemSimple.xml" />
+  <include ref="../../DetFCChhTailCatcher/compact/FCChh_TailCatcher.xml" />
 
   <!--
     These can be used as replacement if you want to use only a sub-set of detectors:

--- a/Detector/DetFCChhTailCatcher/compact/FCChh_TailCatcher.xml
+++ b/Detector/DetFCChhTailCatcher/compact/FCChh_TailCatcher.xml
@@ -32,39 +32,39 @@
     <!-- Barrel -->
     <detector id="12" name="MuonEnvelope" type="SimpleCylinder" sensitive="true" readout="Muons_Readout" vis="MuonEnvelopeVis">
       <comment>Envelope for Muon Barrel</comment>
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="FullParticleAbsSD"/>
       <dimensions rmin="BarMuon_rmax2" rmax="BarMuon_rmax2+MuonSpacer" dz="BarMuon_z2-MuonSpacer" phi0="0" deltaphi="360*deg" z_offset="0*cm" material="Aluminum"/>
     </detector>
     <detector id="60" name="MuonEnvelopeExtBarrelPos" type="SimpleCylinder" sensitive="true" readout="Muons_Readout" vis="MuonEnvelopeVis">
       <comment>Envelope for Muon extended Barrel</comment>
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="FullParticleAbsSD"/>
       <dimensions rmin="BarMuon_rmin1" rmax="BarMuon_rmax1" dz="MuonSpacer" phi0="0" deltaphi="360*deg" z_offset="BarMuon_z2" material="Aluminum"/>
     </detector>
     <detector id="124" name="MuonEnvelopeExtBarrelNeg" type="SimpleCylinder" sensitive="true" readout="Muons_Readout" vis="MuonEnvelopeVis">
       <comment>Envelope for Muon extended Barrel</comment>
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="FullParticleAbsSD"/>
       <dimensions rmin="BarMuon_rmin1" rmax="BarMuon_rmax1" dz="MuonSpacer" phi0="0" deltaphi="360*deg" z_offset="-BarMuon_z2" material="Aluminum"/>
     </detector>
     <!-- End-caps -->
     <detector id="61" name="MuonEnvelopeEndcapPos" type="SimpleCylinder" sensitive="true" readout="Muons_Readout" vis="MuonEnvelopeEndcapVis">
       <comment>Envelope for Muon positive end-cap</comment>
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="FullParticleAbsSD"/>
       <dimensions rmin="EndCapMuon_rmin1" rmax="EndCapMuon_rmax2" dz="MuonSpacer" phi0="0" deltaphi="360*deg" z_offset="EndCapMuon_zOffset-EndCapMuon_dz" material="Aluminum"/>
     </detector>
     <detector id="125" name="MuonEnvelopeEndcapNeg" type="SimpleCylinder" sensitive="true" readout="Muons_Readout" vis="MuonEnvelopeEndcapVis">
       <comment>Envelope for Muon positive end-cap</comment>
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="FullParticleAbsSD"/>
       <dimensions rmin="EndCapMuon_rmin1" rmax="EndCapMuon_rmax2" dz="MuonSpacer" phi0="0" deltaphi="360*deg" z_offset="-EndCapMuon_zOffset+EndCapMuon_dz" material="Aluminum"/>
     </detector>
     <!-- Forward -->
     <detector id="63" name="MuonEnvelopeFwdPos" type="SimpleCylinder" sensitive="true" readout="Muons_Readout" vis="MuonEnvelopeFwdVis">
       <comment>Envelope for forward Muon positive</comment>
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="FullParticleAbsSD"/>
       <dimensions rmin="FwdMuon_rmin" rmax="FwdMuon_rmax" dz="MuonSpacer" phi0="0" deltaphi="360*deg" z_offset="FwdMuon_zOffset-FwdMuon_dz" material="Aluminum"/>
     </detector>
     <detector id="127" name="MuonEnvelopeFwdNeg" type="SimpleCylinder" sensitive="true" readout="Muons_Readout" vis="MuonEnvelopeFwdVis">
       <comment>Envelope for forward Muon positive</comment>
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="FullParticleAbsSD"/>
       <dimensions rmin="FwdMuon_rmin" rmax="FwdMuon_rmax" dz="MuonSpacer" phi0="0" deltaphi="360*deg" z_offset="-FwdMuon_zOffset+FwdMuon_dz" material="Aluminum"/>
     </detector>
   </detectors>

--- a/Detector/DetSensitive/CMakeLists.txt
+++ b/Detector/DetSensitive/CMakeLists.txt
@@ -53,3 +53,6 @@ gaudi_add_test(InternalCalorimeterSD
 gaudi_add_test(ExternalCalorimeterSD
                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Detector/DetSensitive/tests/
                FRAMEWORK tests/options/testSimpleCaloSD.py)
+gaudi_add_test(FullParticleAbsSD
+               WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Detector/DetSensitive/tests/
+               FRAMEWORK tests/options/testDd4hepFullParticleAbsSD.py)

--- a/Detector/DetSensitive/DetSensitive/FullParticleAbsSD.h
+++ b/Detector/DetSensitive/DetSensitive/FullParticleAbsSD.h
@@ -9,11 +9,10 @@
 #include "G4THitsCollection.hh"
 #include "G4VSensitiveDetector.hh"
 
-/** SimpleCalorimeterSD DetectorDescription/DetSensitive/src/SimpleCalorimeterSD.h SimpleCalorimeterSD.h
+/** FullParticleAbsD DetectorDescription/DetSensitive/src/FullParticleAbsSD.h FullParticleAbsSD.h
  *
- *  Simple sensitive detector to fully stop the incoming particles.
- *  It is based on DD4hep::Simulation::Geant4GenericSD<Calorimeter> (but it is not identical).
- *  In particular, the position of the hit is set to G4Step::GetPreStepPoint() position.
+ *  Sensitive detector to fully stop the incoming particles.
+ *  The position of the hit is set to G4Step::GetPreStepPoint() position.
  *  New hit is created for each incoming particle, the energy is stored and the track is removed.
  *  No timing information is saved.
  *

--- a/Detector/DetSensitive/DetSensitive/FullParticleAbsSD.h
+++ b/Detector/DetSensitive/DetSensitive/FullParticleAbsSD.h
@@ -1,0 +1,58 @@
+#ifndef DETSENSITIVE_FULLPARTICLEABSSD_H
+#define DETSENSITIVE_FULLPARTICLEABSSD_H
+
+// DD4hep
+#include "DDG4/Geant4Hits.h"
+#include "DDSegmentation/Segmentation.h"
+
+// Geant
+#include "G4THitsCollection.hh"
+#include "G4VSensitiveDetector.hh"
+
+/** SimpleCalorimeterSD DetectorDescription/DetSensitive/src/SimpleCalorimeterSD.h SimpleCalorimeterSD.h
+ *
+ *  Simple sensitive detector to fully stop the incoming particles.
+ *  It is based on DD4hep::Simulation::Geant4GenericSD<Calorimeter> (but it is not identical).
+ *  In particular, the position of the hit is set to G4Step::GetPreStepPoint() position.
+ *  New hit is created for each incoming particle, the energy is stored and the track is removed.
+ *  No timing information is saved.
+ *
+ *  @author    Coralie Neubueser
+ */
+
+namespace det {
+class FullParticleAbsSD : public G4VSensitiveDetector {
+public:
+  /** Constructor.
+   *  @param aDetectorName Name of the detector
+   *  @param aReadoutName Name of the readout (used to name the collection)
+   *  @param aSeg Segmentation of the detector (used to retrieve the cell ID)
+   */
+  FullParticleAbsSD(const std::string& aDetectorName,
+                    const std::string& aReadoutName,
+                    const DD4hep::Geometry::Segmentation& aSeg);
+  /// Destructor
+  virtual ~FullParticleAbsSD();
+  /** Initialization.
+   *  Creates the hit collection with the name passed in the constructor.
+   *  The hit collection is registered in Geant.
+   *  @param aHitsCollections Geant hits collection.
+   */
+  virtual void Initialize(G4HCofThisEvent* aHitsCollections) final;
+  /** Process hit once the particle hit the sensitive volume.
+   *  Gets the kinetic energy from the particle track, calculates the position and cellID,
+   *  saves that into the hit collection.
+   *  New hit is created for first track of each particle within sensitive detector.
+   *  @param aStep Step in which particle deposited the energy.
+   */
+  virtual bool ProcessHits(G4Step* aStep, G4TouchableHistory*) final;
+
+private:
+  /// Collection of calorimeter hits
+  G4THitsCollection<DD4hep::Simulation::Geant4CalorimeterHit>* m_calorimeterCollection;
+  /// Segmentation of the detector used to retrieve the cell Ids
+  DD4hep::Geometry::Segmentation m_seg;
+};
+}
+
+#endif /* DETSENSITIVE_FULLPARTICLEPABSSD_H */

--- a/Detector/DetSensitive/src/FullParticleAbsSD.cpp
+++ b/Detector/DetSensitive/src/FullParticleAbsSD.cpp
@@ -34,7 +34,6 @@ void FullParticleAbsSD::Initialize(G4HCofThisEvent* aHitsCollections) {
 }
 
 bool FullParticleAbsSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
-  // as in DD4hep::Simulation::Geant4GenericSD<Calorimeter>
   CLHEP::Hep3Vector prePos = aStep->GetPreStepPoint()->GetPosition();
   G4Track* aTrack = aStep->GetTrack();
   G4double kineticEnergy = aTrack->GetKineticEnergy();

--- a/Detector/DetSensitive/src/FullParticleAbsSD.cpp
+++ b/Detector/DetSensitive/src/FullParticleAbsSD.cpp
@@ -15,8 +15,8 @@
 
 namespace det {
 FullParticleAbsSD::FullParticleAbsSD(const std::string& aDetectorName,
-                                         const std::string& aReadoutName,
-                                         const DD4hep::Geometry::Segmentation& aSeg)
+                                     const std::string& aReadoutName,
+                                     const DD4hep::Geometry::Segmentation& aSeg)
     : G4VSensitiveDetector(aDetectorName), m_calorimeterCollection(nullptr), m_seg(aSeg) {
   // name of the collection of hits is determined byt the readout name (from XML)
   collectionName.insert(aReadoutName);
@@ -36,7 +36,7 @@ void FullParticleAbsSD::Initialize(G4HCofThisEvent* aHitsCollections) {
 bool FullParticleAbsSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   // as in DD4hep::Simulation::Geant4GenericSD<Calorimeter>
   CLHEP::Hep3Vector prePos = aStep->GetPreStepPoint()->GetPosition();
-  G4Track *aTrack = aStep->GetTrack();
+  G4Track* aTrack = aStep->GetTrack();
   G4double kineticEnergy = aTrack->GetKineticEnergy();
   DD4hep::Simulation::Position pos(prePos.x(), prePos.y(), prePos.z());
   auto hit = new DD4hep::Simulation::Geant4CalorimeterHit(pos);

--- a/Detector/DetSensitive/src/FullParticleAbsSD.cpp
+++ b/Detector/DetSensitive/src/FullParticleAbsSD.cpp
@@ -1,0 +1,50 @@
+#include "DetSensitive/FullParticleAbsSD.h"
+
+// FCCSW
+#include "DetCommon/DetUtils.h"
+
+// DD4hep
+#include "DDG4/Geant4Mapping.h"
+#include "DDG4/Geant4VolumeManager.h"
+
+// CLHEP
+#include "CLHEP/Vector/ThreeVector.h"
+
+// Geant4
+#include "G4SDManager.hh"
+
+namespace det {
+FullParticleAbsSD::FullParticleAbsSD(const std::string& aDetectorName,
+                                         const std::string& aReadoutName,
+                                         const DD4hep::Geometry::Segmentation& aSeg)
+    : G4VSensitiveDetector(aDetectorName), m_calorimeterCollection(nullptr), m_seg(aSeg) {
+  // name of the collection of hits is determined byt the readout name (from XML)
+  collectionName.insert(aReadoutName);
+}
+
+FullParticleAbsSD::~FullParticleAbsSD() {}
+
+void FullParticleAbsSD::Initialize(G4HCofThisEvent* aHitsCollections) {
+  // create a collection of hits and add it to G4HCofThisEvent
+  // deleted in ~G4Event
+  m_calorimeterCollection =
+      new G4THitsCollection<DD4hep::Simulation::Geant4CalorimeterHit>(SensitiveDetectorName, collectionName[0]);
+  aHitsCollections->AddHitsCollection(G4SDManager::GetSDMpointer()->GetCollectionID(m_calorimeterCollection),
+                                      m_calorimeterCollection);
+}
+
+bool FullParticleAbsSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
+  // as in DD4hep::Simulation::Geant4GenericSD<Calorimeter>
+  CLHEP::Hep3Vector prePos = aStep->GetPreStepPoint()->GetPosition();
+  G4Track *aTrack = aStep->GetTrack();
+  G4double kineticEnergy = aTrack->GetKineticEnergy();
+  DD4hep::Simulation::Position pos(prePos.x(), prePos.y(), prePos.z());
+  auto hit = new DD4hep::Simulation::Geant4CalorimeterHit(pos);
+  hit->cellID = utils::cellID(m_seg, *aStep);
+  hit->energyDeposit = kineticEnergy;
+  m_calorimeterCollection->insert(hit);
+  // kill the track to ensure no double counting
+  aTrack->SetTrackStatus(fStopAndKill);
+  return true;
+}
+}

--- a/Detector/DetSensitive/src/SDWrapper.cpp
+++ b/Detector/DetSensitive/src/SDWrapper.cpp
@@ -7,6 +7,7 @@
 #include "DetSensitive/MiddleStepTrackerSD.h"
 #include "DetSensitive/SimpleCalorimeterSD.h"
 #include "DetSensitive/SimpleTrackerSD.h"
+#include "DetSensitive/FullParticleAbsSD.h"
 
 namespace DD4hep {
 namespace Simulation {
@@ -53,6 +54,13 @@ static G4VSensitiveDetector* create_gflash_calorimeter_sd(const std::string& aDe
   return new det::GflashCalorimeterSD(
       aDetectorName, readoutName, aLcdd.sensitiveDetector(aDetectorName).readout().segmentation());
 }
+  // Factory method to create an instance of FullParticleAbsSD
+  static G4VSensitiveDetector* create_full_particle_absorbtion_sd(const std::string& aDetectorName,
+							   DD4hep::Geometry::LCDD& aLcdd) {
+  std::string readoutName = aLcdd.sensitiveDetector(aDetectorName).readout().name();
+  return new det::FullParticleAbsSD(
+      aDetectorName, readoutName, aLcdd.sensitiveDetector(aDetectorName).readout().segmentation());
+}
 }
 }
 DECLARE_EXTERNAL_GEANT4SENSITIVEDETECTOR(SimpleTrackerSD, DD4hep::Simulation::create_simple_tracker_sd)
@@ -61,3 +69,4 @@ DECLARE_EXTERNAL_GEANT4SENSITIVEDETECTOR(SimpleCalorimeterSD, DD4hep::Simulation
 DECLARE_EXTERNAL_GEANT4SENSITIVEDETECTOR(BirksLawCalorimeterSD, DD4hep::Simulation::create_birks_law_calorimeter_sd)
 DECLARE_EXTERNAL_GEANT4SENSITIVEDETECTOR(AggregateCalorimeterSD, DD4hep::Simulation::create_aggregate_calorimeter_sd)
 DECLARE_EXTERNAL_GEANT4SENSITIVEDETECTOR(GflashCalorimeterSD, DD4hep::Simulation::create_gflash_calorimeter_sd)
+DECLARE_EXTERNAL_GEANT4SENSITIVEDETECTOR(FullParticleAbsSD, DD4hep::Simulation::create_full_particle_absorbtion_sd)

--- a/Detector/DetSensitive/src/SDWrapper.cpp
+++ b/Detector/DetSensitive/src/SDWrapper.cpp
@@ -3,11 +3,11 @@
 
 #include "DetSensitive/AggregateCalorimeterSD.h"
 #include "DetSensitive/BirksLawCalorimeterSD.h"
+#include "DetSensitive/FullParticleAbsSD.h"
 #include "DetSensitive/GflashCalorimeterSD.h"
 #include "DetSensitive/MiddleStepTrackerSD.h"
 #include "DetSensitive/SimpleCalorimeterSD.h"
 #include "DetSensitive/SimpleTrackerSD.h"
-#include "DetSensitive/FullParticleAbsSD.h"
 
 namespace DD4hep {
 namespace Simulation {
@@ -54,9 +54,9 @@ static G4VSensitiveDetector* create_gflash_calorimeter_sd(const std::string& aDe
   return new det::GflashCalorimeterSD(
       aDetectorName, readoutName, aLcdd.sensitiveDetector(aDetectorName).readout().segmentation());
 }
-  // Factory method to create an instance of FullParticleAbsSD
-  static G4VSensitiveDetector* create_full_particle_absorbtion_sd(const std::string& aDetectorName,
-							   DD4hep::Geometry::LCDD& aLcdd) {
+// Factory method to create an instance of FullParticleAbsSD
+static G4VSensitiveDetector* create_full_particle_absorbtion_sd(const std::string& aDetectorName,
+                                                                DD4hep::Geometry::LCDD& aLcdd) {
   std::string readoutName = aLcdd.sensitiveDetector(aDetectorName).readout().name();
   return new det::FullParticleAbsSD(
       aDetectorName, readoutName, aLcdd.sensitiveDetector(aDetectorName).readout().segmentation());

--- a/Detector/DetSensitive/tests/compact/Box_dd4hepStopParticleSD.xml
+++ b/Detector/DetSensitive/tests/compact/Box_dd4hepStopParticleSD.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <includes>
+    <gdmlFile  ref="../../../DetCommon/compact/elements.xml"/>
+    <gdmlFile  ref="../../../DetCommon/compact/materials.xml"/>
+  </includes>
+
+  <info name="Box"
+        title="Box"
+        author="Anna"
+        url="no"
+        version="1"
+        status="development">
+    <comment>Simple box to test the sensitive detector</comment>
+  </info>
+
+  <define>
+    <constant name="world_size" value="5.*m"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+    <constant name="box_x" value="0.51*m"/> <!-- WARNING: half length -->
+    <constant name="box_y" value="0.51*m"/> <!-- WARNING: half length -->
+    <constant name="box_z" value="0.51*m"/> <!-- WARNING: half length -->
+  </define>
+
+  <display>
+    <vis name="BoxVis" r="0.5" g="0.0" b="0.5" alpha="0.2" showDaugthers="true" visible="false" />
+        <vis name="comp0" r="0." g="0." b="1.0" alpha="0.6" showDaugthers="true" visible="true" drawingStyle="solid"/>
+  </display>
+
+  <readouts>
+    <readout name="Hits">
+      <segmentation type="CartesianGridXYZ" grid_size_x="2*cm" grid_size_y="2.*cm" grid_size_z="2.*cm"/>
+      <id>z:-6,y:-6,x:-6,system:1</id>
+    </readout>
+  </readouts>
+
+  <detectors>
+    <detector id="0" name="BoxECal" type="SimpleBox" readout="Hits" sensitive="true">
+      <material name="AluminumOxide"/>
+      <sensitive type="FullParticleAbsSD"/>
+      <dimensions x="box_x" y="box_y" z="box_z"/>
+      <position   x="0"     y="0"     z="box_z"/>
+      <rotation   x="0"     y="0"     z="0"/>
+    </detector>
+  </detectors>
+
+</lccdd>

--- a/Detector/DetSensitive/tests/options/testDd4hepFullParticleAbsSD.py
+++ b/Detector/DetSensitive/tests/options/testDd4hepFullParticleAbsSD.py
@@ -1,0 +1,63 @@
+from Gaudi.Configuration import *
+
+from Configurables import GenAlg, MomentumRangeParticleGun, Gaudi__ParticlePropertySvc
+pgun = MomentumRangeParticleGun("PGun",
+                                PdgCodes=[11], # electron
+                                MomentumMin = 10, # GeV
+                                MomentumMax = 10, # GeV
+                                ThetaMin = -0.45, # rad
+                                ThetaMax = -0.45, # rad
+                                PhiMin = 1.6, # rad
+                                PhiMax = 1.6) # rad
+gen = GenAlg("ParticleGun", SignalProvider=pgun)
+gen.hepmc.Path = "hepmc"
+ppservice = Gaudi__ParticlePropertySvc("ParticlePropertySvc", ParticlePropertiesFile="Generation/data/ParticleTable.txt")
+
+from Configurables import HepMCToEDMConverter
+hepmc_converter = HepMCToEDMConverter("Converter")
+hepmc_converter.hepmc.Path="hepmc"
+hepmc_converter.genparticles.Path="allGenParticles"
+hepmc_converter.genvertices.Path="allGenVertices"
+
+from Configurables import HepMCDumper
+hepmc_dump = HepMCDumper("hepmc")
+hepmc_dump.hepmc.Path="hepmc"
+
+from Configurables import GeoSvc
+geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetSensitive/tests/compact/Box_dd4hepStopParticleSD.xml'], OutputLevel = DEBUG)
+
+from Configurables import SimG4Svc
+geantservice = SimG4Svc("SimG4Svc",
+                        detector='SimG4DD4hepDetector',
+                        physicslist="SimG4FtfpBert",
+                        actions="SimG4FullSimActions")
+
+from Configurables import SimG4Alg, SimG4SaveCalHits, SimG4PrimariesFromEdmTool, InspectHitsCollectionsTool
+inspecttool = InspectHitsCollectionsTool("inspect", readoutNames=["Hits"], OutputLevel = DEBUG)
+
+saveParticletool = SimG4SaveCalHits("saveParticles", readoutNames = ["Hits"])
+saveParticletool.positionedCaloHits.Path = "positionedCaloHits"
+saveParticletool.caloHits.Path = "caloHits"
+
+particle_converter = SimG4PrimariesFromEdmTool("EdmConverter")
+particle_converter.genParticles.Path = "allGenParticles"
+geantsim = SimG4Alg("SimG4Alg",
+                    outputs=["SimG4SaveCalHits/saveParticles",
+                             "InspectHitsCollectionsTool/inspect"],
+                    eventProvider=particle_converter)
+
+from Configurables import FCCDataSvc, PodioOutput
+podiosvc = FCCDataSvc("EventDataSvc")
+out = PodioOutput("out", OutputLevel=DEBUG, filename="out_dd4hepStopParticleSD.root")
+out.outputCommands = ["keep *"]
+
+
+# ApplicationMgr
+from Configurables import ApplicationMgr
+ApplicationMgr( TopAlg = [gen, hepmc_converter, hepmc_dump, geantsim, out],
+                EvtSel = 'NONE',
+                EvtMax   = 1,
+                # order is important, as GeoSvc is needed by SimG4Svc
+                ExtSvc = [podiosvc, ppservice, geoservice, geantservice],
+                OutputLevel=DEBUG
+ )

--- a/Detector/DetSensitive/tests/options/testDd4hepFullParticleAbsSD.py
+++ b/Detector/DetSensitive/tests/options/testDd4hepFullParticleAbsSD.py
@@ -11,7 +11,7 @@ pgun = MomentumRangeParticleGun("PGun",
                                 PhiMax = 1.6) # rad
 gen = GenAlg("ParticleGun", SignalProvider=pgun)
 gen.hepmc.Path = "hepmc"
-ppservice = Gaudi__ParticlePropertySvc("ParticlePropertySvc", ParticlePropertiesFile="Generation/data/ParticleTable.txt")
+ppservice = Gaudi__ParticlePropertySvc("ParticlePropertySvc", ParticlePropertiesFile="../../../Generation/data/ParticleTable.txt")
 
 from Configurables import HepMCToEDMConverter
 hepmc_converter = HepMCToEDMConverter("Converter")
@@ -24,7 +24,7 @@ hepmc_dump = HepMCDumper("hepmc")
 hepmc_dump.hepmc.Path="hepmc"
 
 from Configurables import GeoSvc
-geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetSensitive/tests/compact/Box_dd4hepStopParticleSD.xml'], OutputLevel = DEBUG)
+geoservice = GeoSvc("GeoSvc", detectors=['file:compact/Box_dd4hepStopParticleSD.xml'], OutputLevel = DEBUG)
 
 from Configurables import SimG4Svc
 geantservice = SimG4Svc("SimG4Svc",


### PR DESCRIPTION

Changes proposed in this pull-request:

- new sensitive detector "FullParticleAbsSD": it stores the truth energy and position of the incoming particle, and deletes it afterwards
- renamed the "SimpleMuon" geometry to "TailCatcher"; since the thin layers at front of muon chamber positions will be used as a tail catcher, including the new sensitive detector
- the minimum radius in Fwd region of the Muon system is adjusted to beam tube 
