### PR TITLE
Better INFO printouts 

### DIFF
--- a/Detector/DetComponents/src/GeoConstruction.cpp
+++ b/Detector/DetComponents/src/GeoConstruction.cpp
@@ -66,7 +66,7 @@ void GeoConstruction::ConstructSDandField() {
 G4VPhysicalVolume* GeoConstruction::Construct() {
   DD4hep::Simulation::Geant4Mapping& g4map = DD4hep::Simulation::Geant4Mapping::instance();
   DD4hep::Geometry::DetElement world = m_lcdd.world();
-  DD4hep::Simulation::Geant4Converter conv(m_lcdd, DD4hep::INFO);
+  DD4hep::Simulation::Geant4Converter conv(m_lcdd, DD4hep::DEBUG);
   DD4hep::Simulation::Geant4GeometryInfo* geo_info = conv.create(world).detach();
   g4map.attach(geo_info);
   // All volumes are deleted in ~G4PhysicalVolumeStore()

--- a/Detector/DetComponents/src/GeoSvc.cpp
+++ b/Detector/DetComponents/src/GeoSvc.cpp
@@ -9,6 +9,7 @@
 #include "GeoSvc.h"
 #include "GaudiKernel/Service.h"
 #include "GeoConstruction.h"
+#include "TGeoManager.h"
 
 #include "DD4hep/Printout.h"
 
@@ -24,6 +25,10 @@ GeoSvc::~GeoSvc() { m_dd4hepgeo->destroyInstance(); }
 StatusCode GeoSvc::initialize() {
   StatusCode sc = Service::initialize();
   if (!sc.isSuccess()) return sc;
+  // Turn off TGeo printouts if appropriate for the msg level
+  if (msgLevel() >= MSG::INFO) {
+    TGeoManager::SetVerboseLevel(0);
+  }
   uint printoutLevel = msgLevel();
   DD4hep::setPrintLevel(DD4hep::PrintLevel(printoutLevel));
   m_incidentSvc->addListener(this, "GeometryFailure");

--- a/Examples/options/dumpGeo.py
+++ b/Examples/options/dumpGeo.py
@@ -2,7 +2,7 @@ import os
 from Gaudi.Configuration import *
 
 from Configurables import GeoSvc
-geoservice = GeoSvc("GeoSvc", detectors=['file:../Detector/DetSensitive/tests/compact/Box_simpleTrackerSD.xml'], OutputLevel = DEBUG)
+geoservice = GeoSvc("GeoSvc", detectors=['file:../Detector/DetSensitive/tests/compact/Box_simpleTrackerSD.xml'], OutputLevel = INFO)
 
 from Configurables import SimG4Svc
 geantservice = SimG4Svc("SimG4Svc",

--- a/Examples/options/geant_fastsim.py
+++ b/Examples/options/geant_fastsim.py
@@ -29,7 +29,8 @@ from Configurables import GeoSvc
 ## parse the given xml file
 geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
                                          'file:Detector/DetFCChhBaseline1/compact/FCChh_TrackerAir.xml',
-                                         'file:Detector/DetFCChhECalSimple/compact/FCChh_ECalBarrel_Gflash.xml'])
+                                         'file:Detector/DetFCChhECalSimple/compact/FCChh_ECalBarrel_Gflash.xml'],
+                                        OutputLevel=INFO )
 
 # Geant4 service
 # Configures the Geant simulation: geometry, physics list and user actions

--- a/Examples/options/geant_fastsim_tklayout.py
+++ b/Examples/options/geant_fastsim_tklayout.py
@@ -20,7 +20,8 @@ hepmc_converter.genvertices.Path="allGenVertices"
 # Parses the given xml file
 from Configurables import GeoSvc
 geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
-                                         'file:Detector/DetFCChhBaseline1/compact/FCChh_TrackerAir.xml'])
+                                         'file:Detector/DetFCChhBaseline1/compact/FCChh_TrackerAir.xml'],
+                                         OutputLevel=INFO)
 
 # Geant4 service
 # Configures the Geant simulation: geometry, physics list and user actions

--- a/Examples/options/geant_fullsim.py
+++ b/Examples/options/geant_fullsim.py
@@ -29,7 +29,8 @@ hepmc_converter.genvertices.Path="allGenVertices"
 # Parses the given xml file
 from Configurables import GeoSvc
 geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
-  'file:Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml'])
+  'file:Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml'],
+  OutputLevel=INFO)
 
 # Geant4 service
 # Configures the Geant simulation: geometry, physics list and user actions

--- a/Examples/options/geant_fullsim_field.py
+++ b/Examples/options/geant_fullsim_field.py
@@ -24,7 +24,7 @@ ppservice = Gaudi__ParticlePropertySvc("ParticlePropertySvc", ParticleProperties
 from Configurables import GeoSvc
 geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
   'file:Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml'],
-                    OutputLevel = DEBUG)
+                    OutputLevel = INFO)
 
 from Configurables import HepMCToEDMConverter
 ## Reads an HepMC::GenEvent from the data service and writes a collection of EDM Particles

--- a/Examples/options/geant_pgun_fullsim.py
+++ b/Examples/options/geant_pgun_fullsim.py
@@ -42,7 +42,7 @@ geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compac
                                          'file:Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml',
                                          'file:Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml',
                                          'file:Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml'],
-                    OutputLevel = DEBUG)
+                    OutputLevel = INFO)
 
 from Configurables import SimG4Svc
 ## Geant4 service

--- a/Examples/options/interactive_mode.py
+++ b/Examples/options/interactive_mode.py
@@ -11,7 +11,7 @@ from Configurables import GeoSvc
 geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
                                          'file:Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml'
                                          ],
-                    OutputLevel = DEBUG)
+                    OutputLevel = INFO)
 
 # Geant4 service
 # Configures the Geant simulation: geometry, physics list and user actions

--- a/Test/TestReconstruction/tests/options/geant_fullsim_pgun_geantino.py
+++ b/Test/TestReconstruction/tests/options/geant_fullsim_pgun_geantino.py
@@ -9,7 +9,7 @@ podioevent = FCCDataSvc("EventDataSvc")
 from Configurables import GeoSvc, SimG4SingleParticleGeneratorTool
 geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
   'file:Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml'],
-                    OutputLevel = DEBUG)
+                    OutputLevel = INFO)
 
 
 # Geant4 service


### PR DESCRIPTION
More appropriate printouts for the INFO msg level, getting rid of many lines of 
```
Geant4Converter  INFO  ++ Volume     + CalEndcapCryoOuter_negative_SimpleCylinder converted: 0xd024d1e0 ---> G4: 0xf3967da0
```
and
```
Info in <TGeoManager::SetTopVolume>: Top volume is world_volume. Master volume is world_volume
Info in <TGeoNavigator::BuildCache>: --- Maximum geometry depth set to 100
Detector         WARN  +++ Object 'compact_checksum' is already defined and new one will be ignored
Info in <TGeoManager::CheckGeometry>: Fixing runtime shapes...
Info in <TGeoManager::CheckGeometry>: ...Nothing to fix
Info in <TGeoManager::CloseGeometry>: Counting nodes...
Info in <TGeoManager::Voxelize>: Voxelizing...
Info in <TGeoManager::CloseGeometry>: Building cache...
Info in <TGeoManager::CountLevels>: max level = 1, max placements = 0
Info in <TGeoManager::CloseGeometry>: 1 nodes/ 1 volume UID's in Detector Geometry
Info in <TGeoManager::CloseGeometry>: ----------------modeler ready----------------
```
that is written to stderr.

