### PR TITLE
Add default permissions when installing run file executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,9 @@ find_package(GaudiProject)
 configure_file(cmake/fccrun.in ${CMAKE_BINARY_DIR}/fccrun)
 install(FILES ${CMAKE_BINARY_DIR}/fccrun
         DESTINATION .
-        PERMISSIONS WORLD_EXECUTE WORLD_READ
+        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ 
+                    GROUP_EXECUTE GROUP_READ
+                    WORLD_EXECUTE WORLD_READ
         RENAME run)
 
 gaudi_project(FCCSW HEAD


### PR DESCRIPTION
Addresses a problem installing `FCCSW` with [Spack](https://github.com/spack/spack). During the `make install` phase, the file
`fccrun.in` is installed in the prefix path with execute and read permissions only for the rest of users, but not for the group and owner.   

Changes proposed in this pull-request:

- Add all permissions for the OWNER
- Add Execute and read permissions for the GROUP
- Maintain current WORLD permissions

Those owner and group permissions are set by default, however
the current PERMISSIONS parameters override them. 