### PR TITLE
Update vertex parameters for v0.9.1

### DIFF
--- a/Generation/python/FCCPileupScenarios.py
+++ b/Generation/python/FCCPileupScenarios.py
@@ -15,9 +15,9 @@ _CommonFCCPileupConf = {
           "yVertexMean": 0 * units.mm,
           "yVertexSigma": 0.5 * units.mm,
           "zVertexMean": 0 * units.mm,
-          "zVertexSigma": 70 * units.mm,
+          "zVertexSigma": 40 * units.mm,
           "tVertexMean": 0 * units.picosecond,
-          "tVertexSigma": 120 * units.picosecond,
+          "tVertexSigma": 180 * units.picosecond,
            }
 
 


### PR DESCRIPTION
This fixes a bug that took the rms bunch size instead of the vertex spread in z
