### PR TITLE
Add option to allow empty signal collection for the pileup overlay

### DIFF
--- a/FWCore/src/components/PileupOverlayAlg.cpp
+++ b/FWCore/src/components/PileupOverlayAlg.cpp
@@ -39,8 +39,10 @@ StatusCode PileupOverlayAlg::finalize() {
 StatusCode PileupOverlayAlg::execute() {
   unsigned nEvents = m_reader.getEntries();
 
-  for (auto& tool : m_mergeTools) {
-    tool->readSignal();
+  if (!m_noSignal) {
+    for (auto& tool : m_mergeTools) {
+      tool->readSignal();
+    }
   }
 
   const unsigned int numPileUp = m_pileUpTool->numberOfPileUp();

--- a/FWCore/src/components/PileupOverlayAlg.h
+++ b/FWCore/src/components/PileupOverlayAlg.h
@@ -57,6 +57,8 @@ private:
   Gaudi::Property<std::vector<std::string>> m_pileupFilenames{
       this, "pileupFilenames", {"min_bias_pool.root"}, "Name of File containing pileup events"};
   Gaudi::Property<bool> m_doShuffleInputFiles{this, "doShuffleInputFiles", false, "Shuffle list of input files for additional randomization"};
+
+  Gaudi::Property<bool> m_noSignal{this, "noSignal", false, "Set to true if you don't want to provide a signal collection"};
   /// store for the minimum bias file
   podio::EventStore m_store;
   /// reader for the minimum bias file


### PR DESCRIPTION
Similar to #296, but for the overlay algorithm.

This allows to skip setting a signal input collection, as long as  following option is used:
```
overlay.noSignal = True
```