### PR TITLE
Specify user limits

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -73,6 +73,9 @@ gaudi_add_test(CheckMergeCollection
                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                COMMAND python FWCore/tests/scripts/check_coll_after_merge.py
                DEPENDS PileupOverlay)
+gaudi_add_test(GeantUserLimits
+               WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+               FRAMEWORK options/geant_userLimits.py)
 
 # Test of the format-checker:
 gaudi_add_test(FormatCheckerOneFile

--- a/Examples/options/geant_userLimits.py
+++ b/Examples/options/geant_userLimits.py
@@ -29,7 +29,7 @@ from Configurables import SimG4Svc, SimG4UserLimitPhysicsList, SimG4UserLimitReg
 from GaudiKernel.SystemOfUnits import mm
 ## create region and a parametrisation model, pass smearing tool
 regiontool = SimG4UserLimitRegion("limits", volumeNames=["TrackerEnvelopeBarrel"],
-                                       maxStep = 1)
+                                       maxStep = 1*mm)
 # create overlay on top of FTFP_BERT physics list, attaching fast sim/parametrization process
 physicslisttool = SimG4UserLimitPhysicsList("Physics", fullphysics="SimG4FtfpBert")
 # attach those tools to the G4 service

--- a/Examples/options/geant_userLimits.py
+++ b/Examples/options/geant_userLimits.py
@@ -1,0 +1,60 @@
+from Gaudi.Configuration import *
+
+# Data service
+from Configurables import FCCDataSvc
+podioevent = FCCDataSvc("EventDataSvc")
+
+from Configurables import HepMCFileReader, GenAlg
+readertool = HepMCFileReader("ReaderTool", Filename="/eos/project/f/fccsw-web/testsamples/FCC_minbias_100TeV.dat")
+reader = GenAlg("Reader", SignalProvider=readertool)
+reader.hepmc.Path = "hepmc"
+
+# reads an HepMC::GenEvent from the data service and writes a collection of EDM Particles
+from Configurables import HepMCToEDMConverter
+hepmc_converter = HepMCToEDMConverter("Converter")
+hepmc_converter.hepmc.Path="hepmc"
+hepmc_converter.genparticles.Path="allGenParticles"
+hepmc_converter.genvertices.Path="allGenVertices"
+
+# DD4hep geometry service
+# Parses the given xml file
+from Configurables import GeoSvc
+geoservice = GeoSvc("GeoSvc", detectors=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+                                         'file:Detector/DetFCChhBaseline1/compact/FCChh_TrackerAir.xml'],
+                                         OutputLevel=INFO)
+
+# Geant4 service
+# Configures the Geant simulation: geometry, physics list and user actions
+from Configurables import SimG4Svc, SimG4UserLimitPhysicsList, SimG4UserLimitRegion
+from GaudiKernel.SystemOfUnits import mm
+## create region and a parametrisation model, pass smearing tool
+regiontool = SimG4UserLimitRegion("limits", volumeNames=["TrackerEnvelopeBarrel"],
+                                       maxStep = 1)
+# create overlay on top of FTFP_BERT physics list, attaching fast sim/parametrization process
+physicslisttool = SimG4UserLimitPhysicsList("Physics", fullphysics="SimG4FtfpBert")
+# attach those tools to the G4 service
+geantservice = SimG4Svc("SimG4Svc", physicslist=physicslisttool, regions=["SimG4UserLimitRegion/limits"])
+
+# Geant4 algorithm
+# Translates EDM to G4Event, passes the event to G4, writes out outputs via tools
+from Configurables import SimG4Alg, SimG4PrimariesFromEdmTool
+# next, create the G4 algorithm, giving the list of names of tools ("XX/YY")
+particle_converter = SimG4PrimariesFromEdmTool("EdmConverter")
+particle_converter.genParticles.Path = "allGenParticles"
+geantsim = SimG4Alg("SimG4Alg",
+                    eventProvider=particle_converter)
+
+# PODIO algorithm
+from Configurables import PodioOutput
+out = PodioOutput("out", filename = "out_limits.root")
+out.outputCommands = ["keep *"]
+
+# ApplicationMgr
+from Configurables import ApplicationMgr
+ApplicationMgr( TopAlg = [reader, hepmc_converter, geantsim, out],
+                EvtSel = 'NONE',
+                EvtMax   = 1,
+                # order is important, as GeoSvc is needed by SimG4Svc
+                ExtSvc = [podioevent, geoservice, geantservice],
+                OutputLevel=INFO
+ )

--- a/Sim/SimG4Components/src/SimG4Svc.cpp
+++ b/Sim/SimG4Components/src/SimG4Svc.cpp
@@ -96,7 +96,10 @@ StatusCode SimG4Svc::initialize() {
     m_regionTools.push_back(tool);
   }
   for (auto& tool : m_regionTools) {
-    tool->create();
+    if (tool->create().isFailure()) {
+      error() << "Unable to create regions for specified volumes" << endmsg;
+      return StatusCode::FAILURE;
+    }
   }
   for (auto command : m_g4PostInitCommands) {
     UImanager->ApplyCommand(command);

--- a/Sim/SimG4Full/src/components/SimG4UserLimitPhysicsList.cpp
+++ b/Sim/SimG4Full/src/components/SimG4UserLimitPhysicsList.cpp
@@ -1,0 +1,37 @@
+#include "SimG4UserLimitPhysicsList.h"
+
+// FCCSW
+#include "SimG4Interface/ISimG4PhysicsList.h"
+
+// Geant4
+#include "G4VModularPhysicsList.hh"
+#include "G4StepLimiterPhysics.hh"
+
+DECLARE_TOOL_FACTORY(SimG4UserLimitPhysicsList)
+
+SimG4UserLimitPhysicsList::SimG4UserLimitPhysicsList(const std::string& aType, const std::string& aName,
+                                                 const IInterface* aParent)
+    : AlgTool(aType, aName, aParent) {
+  declareInterface<ISimG4PhysicsList>(this);
+  declareProperty("fullphysics", m_physicsListTool, "Handle for the full physics list tool");
+}
+
+SimG4UserLimitPhysicsList::~SimG4UserLimitPhysicsList() {}
+
+StatusCode SimG4UserLimitPhysicsList::initialize() {
+  if (AlgTool::initialize().isFailure()) {
+    return StatusCode::FAILURE;
+  }
+  m_physicsListTool.retrieve();
+  return StatusCode::SUCCESS;
+}
+
+StatusCode SimG4UserLimitPhysicsList::finalize() { return AlgTool::finalize(); }
+
+G4VModularPhysicsList* SimG4UserLimitPhysicsList::physicsList() {
+  // ownership passed to SimG4Svc which will register it in G4RunManager. To be deleted in ~G4RunManager()
+  G4VModularPhysicsList* physicsList = m_physicsListTool->physicsList();
+  // Attach step limiter process
+  physicsList->RegisterPhysics(new G4StepLimiterPhysics());
+  return physicsList;
+}

--- a/Sim/SimG4Full/src/components/SimG4UserLimitPhysicsList.cpp
+++ b/Sim/SimG4Full/src/components/SimG4UserLimitPhysicsList.cpp
@@ -4,13 +4,13 @@
 #include "SimG4Interface/ISimG4PhysicsList.h"
 
 // Geant4
-#include "G4VModularPhysicsList.hh"
 #include "G4StepLimiterPhysics.hh"
+#include "G4VModularPhysicsList.hh"
 
 DECLARE_TOOL_FACTORY(SimG4UserLimitPhysicsList)
 
 SimG4UserLimitPhysicsList::SimG4UserLimitPhysicsList(const std::string& aType, const std::string& aName,
-                                                 const IInterface* aParent)
+                                                     const IInterface* aParent)
     : AlgTool(aType, aName, aParent) {
   declareInterface<ISimG4PhysicsList>(this);
   declareProperty("fullphysics", m_physicsListTool, "Handle for the full physics list tool");

--- a/Sim/SimG4Full/src/components/SimG4UserLimitPhysicsList.h
+++ b/Sim/SimG4Full/src/components/SimG4UserLimitPhysicsList.h
@@ -1,0 +1,42 @@
+#ifndef SIMG4FAST_G4USERLIMITPHYSICSLIST_H
+#define SIMG4FAST_G4USERLIMITPHYSICSLIST_H
+
+// Gaudi
+#include "GaudiKernel/AlgTool.h"
+#include "GaudiKernel/ToolHandle.h"
+
+// FCCSW
+#include "SimG4Interface/ISimG4PhysicsList.h"
+
+/** @class SimG4UserLimitPhysicsList SimG4Fast/src/components/SimG4UserLimitPhysicsList.h SimG4UserLimitPhysicsList.h
+ *
+ *  User limits physics list tool.
+ *  Attaches G4StepLimiterPhysics process to the full simulation physics list.
+ *
+ *  @author Anna Zaborowska
+ */
+
+class SimG4UserLimitPhysicsList : public AlgTool, virtual public ISimG4PhysicsList {
+public:
+  explicit SimG4UserLimitPhysicsList(const std::string& aType, const std::string& aName, const IInterface* aParent);
+  virtual ~SimG4UserLimitPhysicsList();
+
+  /**  Initialize.
+   *   @return status code
+   */
+  virtual StatusCode initialize();
+  /**  Finalize.
+   *   @return status code
+   */
+  virtual StatusCode finalize();
+  /** Get the physics list.
+   *  @return pointer to G4VModularPhysicsList (ownership is transferred to the caller)
+   */
+  virtual G4VModularPhysicsList* physicsList();
+
+private:
+  /// Handle for the full physics list tool
+  ToolHandle<ISimG4PhysicsList> m_physicsListTool{"SimG4FtfpBert", this, true};
+};
+
+#endif /* SIMG4FAST_G4USERLIMITPHYSICSLIST_H */

--- a/Sim/SimG4Full/src/components/SimG4UserLimitRegion.cpp
+++ b/Sim/SimG4Full/src/components/SimG4UserLimitRegion.cpp
@@ -1,0 +1,49 @@
+#include "SimG4UserLimitRegion.h"
+
+// Geant4
+#include "G4RegionStore.hh"
+#include "G4LogicalVolume.hh"
+#include "G4TransportationManager.hh"
+#include "G4UserLimits.hh"
+
+DECLARE_TOOL_FACTORY(SimG4UserLimitRegion)
+
+SimG4UserLimitRegion::SimG4UserLimitRegion(const std::string& type, const std::string& name,
+                                                     const IInterface* parent)
+    : GaudiTool(type, name, parent) {
+  declareInterface<ISimG4RegionTool>(this);
+}
+
+SimG4UserLimitRegion::~SimG4UserLimitRegion() {}
+
+StatusCode SimG4UserLimitRegion::initialize() {
+  if (GaudiTool::initialize().isFailure()) {
+    return StatusCode::FAILURE;
+  }
+  if (m_volumeNames.size() == 0) {
+    error() << "No detector name is specified for the parametrisation" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  return StatusCode::SUCCESS;
+}
+
+StatusCode SimG4UserLimitRegion::finalize() { return GaudiTool::finalize(); }
+
+StatusCode SimG4UserLimitRegion::create() {
+  G4LogicalVolume* world =
+      (*G4TransportationManager::GetTransportationManager()->GetWorldsIterator())->GetLogicalVolume();
+  for (const auto& trackerName : m_volumeNames) {
+    for (int iter_region = 0; iter_region < world->GetNoDaughters(); ++iter_region) {
+      if (world->GetDaughter(iter_region)->GetName().find(trackerName) != std::string::npos) {
+        /// all G4Region objects are deleted by the G4RegionStore
+        m_g4regions.emplace_back(
+            new G4Region(world->GetDaughter(iter_region)->GetLogicalVolume()->GetName() + "_userLimits"));
+        m_g4regions.back()->AddRootLogicalVolume(world->GetDaughter(iter_region)->GetLogicalVolume());
+        // TODO add to shared_ptr vector so it is deleted (it won't be by Geant)
+        m_g4regions.back()->SetUserLimits(new G4UserLimits(m_maxStep, m_maxTrack, m_maxTrack, m_minKineticEnergy, m_minRange));
+        info() << "Creating user limits in the region " << m_g4regions.back()->GetName() << endmsg;
+      }
+    }
+  }
+  return StatusCode::SUCCESS;
+}

--- a/Sim/SimG4Full/src/components/SimG4UserLimitRegion.cpp
+++ b/Sim/SimG4Full/src/components/SimG4UserLimitRegion.cpp
@@ -4,7 +4,6 @@
 #include "G4RegionStore.hh"
 #include "G4LogicalVolume.hh"
 #include "G4TransportationManager.hh"
-#include "G4UserLimits.hh"
 
 DECLARE_TOOL_FACTORY(SimG4UserLimitRegion)
 
@@ -39,11 +38,15 @@ StatusCode SimG4UserLimitRegion::create() {
         m_g4regions.emplace_back(
             new G4Region(world->GetDaughter(iter_region)->GetLogicalVolume()->GetName() + "_userLimits"));
         m_g4regions.back()->AddRootLogicalVolume(world->GetDaughter(iter_region)->GetLogicalVolume());
-        // TODO add to shared_ptr vector so it is deleted (it won't be by Geant)
-        m_g4regions.back()->SetUserLimits(new G4UserLimits(m_maxStep, m_maxTrack, m_maxTrack, m_minKineticEnergy, m_minRange));
+        m_userLimits.emplace_back(new G4UserLimits(m_maxStep, m_maxTrack, m_maxTrack, m_minKineticEnergy, m_minRange));
+        m_g4regions.back()->SetUserLimits(m_userLimits.back().get());
         info() << "Creating user limits in the region " << m_g4regions.back()->GetName() << endmsg;
       }
     }
+  }
+  if (m_g4regions.size() != m_volumeNames.size()) {
+    error() << "Regions  were not created for all the volumes" << endmsg;
+    return StatusCode::FAILURE;
   }
   return StatusCode::SUCCESS;
 }

--- a/Sim/SimG4Full/src/components/SimG4UserLimitRegion.cpp
+++ b/Sim/SimG4Full/src/components/SimG4UserLimitRegion.cpp
@@ -5,6 +5,8 @@
 #include "G4LogicalVolume.hh"
 #include "G4TransportationManager.hh"
 
+#include "GaudiKernel/SystemOfUnits.h"
+
 DECLARE_TOOL_FACTORY(SimG4UserLimitRegion)
 
 SimG4UserLimitRegion::SimG4UserLimitRegion(const std::string& type, const std::string& name,
@@ -38,7 +40,11 @@ StatusCode SimG4UserLimitRegion::create() {
         m_g4regions.emplace_back(
             new G4Region(world->GetDaughter(iter_region)->GetLogicalVolume()->GetName() + "_userLimits"));
         m_g4regions.back()->AddRootLogicalVolume(world->GetDaughter(iter_region)->GetLogicalVolume());
-        m_userLimits.emplace_back(new G4UserLimits(m_maxStep, m_maxTrack, m_maxTrack, m_minKineticEnergy, m_minRange));
+        m_userLimits.emplace_back(new G4UserLimits(m_maxStep / Gaudi::Units::mm * CLHEP::mm,
+                                                   m_maxTrack / Gaudi::Units::mm * CLHEP::mm,
+                                                   m_maxTime / Gaudi::Units::s * CLHEP::s,
+                                                   m_minKineticEnergy / Gaudi::Units::MeV * CLHEP::MeV,
+                                                   m_minRange / Gaudi::Units::mm * CLHEP::mm));
         m_g4regions.back()->SetUserLimits(m_userLimits.back().get());
         info() << "Creating user limits in the region " << m_g4regions.back()->GetName() << endmsg;
       }

--- a/Sim/SimG4Full/src/components/SimG4UserLimitRegion.cpp
+++ b/Sim/SimG4Full/src/components/SimG4UserLimitRegion.cpp
@@ -1,16 +1,15 @@
 #include "SimG4UserLimitRegion.h"
 
 // Geant4
-#include "G4RegionStore.hh"
 #include "G4LogicalVolume.hh"
+#include "G4RegionStore.hh"
 #include "G4TransportationManager.hh"
 
 #include "GaudiKernel/SystemOfUnits.h"
 
 DECLARE_TOOL_FACTORY(SimG4UserLimitRegion)
 
-SimG4UserLimitRegion::SimG4UserLimitRegion(const std::string& type, const std::string& name,
-                                                     const IInterface* parent)
+SimG4UserLimitRegion::SimG4UserLimitRegion(const std::string& type, const std::string& name, const IInterface* parent)
     : GaudiTool(type, name, parent) {
   declareInterface<ISimG4RegionTool>(this);
 }

--- a/Sim/SimG4Full/src/components/SimG4UserLimitRegion.h
+++ b/Sim/SimG4Full/src/components/SimG4UserLimitRegion.h
@@ -1,0 +1,61 @@
+#ifndef SIMG4FULL_SIMG4USERLIMITREGION_H
+#define SIMG4FULL_SIMG4USERLIMITREGION_H
+
+#include <cfloat>
+
+// Gaudi
+#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/ToolHandle.h"
+
+// FCCSW
+#include "SimG4Interface/ISimG4ParticleSmearTool.h"
+#include "SimG4Interface/ISimG4RegionTool.h"
+
+// Geant
+class G4VFastSimulationModel;
+class G4Region;
+
+/** @class SimG4UserLimitRegion SimG4Full/src/components/SimG4UserLimitRegion.h SimG4UserLimitRegion.h
+ *
+ *  Tool for creating regions with user limits.
+ *  It requires SimG4UserLimitPhysics to be used.
+ *
+ *  @author Anna Zaborowska
+*/
+
+class SimG4UserLimitRegion : public GaudiTool, virtual public ISimG4RegionTool {
+public:
+  explicit SimG4UserLimitRegion(const std::string& type, const std::string& name, const IInterface* parent);
+  virtual ~SimG4UserLimitRegion();
+  /**  Initialize.
+   *   @return status code
+   */
+  virtual StatusCode initialize() final;
+  /**  Finalize.
+   *   @return status code
+   */
+  virtual StatusCode finalize() final;
+  /**  Create regions and fast simulation models
+   *   @return status code
+   */
+  virtual StatusCode create() final;
+
+private:
+  /// Regions used to set user limits
+  /// deleted by the G4RegionStore
+  std::vector<G4Region*> m_g4regions;
+  /// Names of the volumes where user limits should be attached (set by job options)
+  Gaudi::Property<std::vector<std::string>> m_volumeNames{this, "volumeNames", {}, "Names of the volumes"};
+  /// max allowed Step size in this volume  (set by job options)
+  Gaudi::Property<double> m_maxStep{this, "maxStep", DBL_MAX, "maximum step"};
+  /// max total track length (set by job options)
+  Gaudi::Property<double> m_maxTrack{this, "maxTrack", DBL_MAX, "maximum total track length"};
+  /// max time (set by job options)
+  Gaudi::Property<double> m_maxTime{this, "maxTime", DBL_MAX, "max time"};
+  /// min kinetic energy  (only for charged particles) (set by job options)
+  Gaudi::Property<double> m_minKineticEnergy{this, "minKineticEnergy", 0, "min kinetic energy"};
+  /// min remaining range (only for charged particles) (set by job options)
+  Gaudi::Property<double> m_minRange{this, "minRange", 0, "min remaining range "};
+};
+
+#endif /* SIMG4FULL_SIMG4USERLIMITREGION_H */

--- a/Sim/SimG4Full/src/components/SimG4UserLimitRegion.h
+++ b/Sim/SimG4Full/src/components/SimG4UserLimitRegion.h
@@ -12,7 +12,7 @@
 #include "SimG4Interface/ISimG4RegionTool.h"
 
 // Geant
-class G4VFastSimulationModel;
+#include "G4UserLimits.hh"
 class G4Region;
 
 /** @class SimG4UserLimitRegion SimG4Full/src/components/SimG4UserLimitRegion.h SimG4UserLimitRegion.h
@@ -44,6 +44,8 @@ private:
   /// Regions used to set user limits
   /// deleted by the G4RegionStore
   std::vector<G4Region*> m_g4regions;
+  /// User limits
+  std::vector<std::unique_ptr<G4UserLimits>> m_userLimits;
   /// Names of the volumes where user limits should be attached (set by job options)
   Gaudi::Property<std::vector<std::string>> m_volumeNames{this, "volumeNames", {}, "Names of the volumes"};
   /// max allowed Step size in this volume  (set by job options)

--- a/Sim/doc/FullSimulation.md
+++ b/Sim/doc/FullSimulation.md
@@ -25,6 +25,7 @@ For additional information on fast simulation in Geant4 [see](FastSimulationUsin
 ## How to
 * [use sensitive detectors](#sensitive-detectors)
 * [change the physics list](#how-to-use-different-physics-list)
+* [specify step/track limits](#how-to-specify-step-or-track-limits)
 * [add user action](#how-to-add-a-user-action)
 * [use fast simulation](FastSimulationUsingGeant.md)
 
@@ -259,6 +260,11 @@ In order to use a different physics list, one needs to construct a physics list 
 
 Any new implementation of a physics list (or any other component) should be presented in a pull request to HEP-FCC/FCCSW.
 
+### How to specify step or track limits
+In order to specify user limits with `SimG4UserLimit` class, one needs to use `SimG4UserLimitPhysicsList`. It attaches additional process to an existing physics list.
+
+Moreover, user needs to specify regions where user limits are to be applied. It can be achieved using `SimG4UserLimitRegion` tool and attaching it to `SimG4Svc`.
+For example see [`Examples/options/geant_userLimits.py`](../../Examples/options/geant_userLimits.py).
 
 
 ### User Actions


### PR DESCRIPTION
Changes proposed in this pull-request:

- implements regions with specified step limits (max step) or track limits (max track length, time etc)
- production cuts are not added, set to defaults of physics list

Validation has been done for a simple envelope (example) and by Valentin for tkLayout tracker.


