### PR TITLE
Adapt code to DD4hep v01.05

### DIFF
--- a/Detector/DetCommon/CMakeLists.txt
+++ b/Detector/DetCommon/CMakeLists.txt
@@ -16,7 +16,7 @@ gaudi_install_headers(DetCommon)
 gaudi_add_library(DetCommon
                  src/*.cpp
                  INCLUDE_DIRS DD4hep ROOT Geant4 DetSegmentation
-                 LINK_LIBRARIES GaudiKernel DD4hep ROOT Geant4 DetSegmentation 
+                 LINK_LIBRARIES GaudiKernel DD4hep ROOT Geant4 DetSegmentation
                  PUBLIC_HEADERS DetCommon)
 
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/compact DESTINATION Detector/DetCommon)

--- a/Detector/DetCommon/DetCommon/DetUtils.h
+++ b/Detector/DetCommon/DetCommon/DetUtils.h
@@ -2,7 +2,7 @@
 #define DETCOMMON_DETUTILS_H
 
 // FCCSW
-#include "DetSegmentation/GridPhiEta.h"
+#include "DetSegmentation/FCCSWGridPhiEta.h"
 
 // DD4hep
 #include "DD4hep/DetFactoryHelper.h"

--- a/Detector/DetCommon/DetCommon/DetUtils.h
+++ b/Detector/DetCommon/DetCommon/DetUtils.h
@@ -2,12 +2,14 @@
 #define DETCOMMON_DETUTILS_H
 
 // FCCSW
-#include "DetSegmentation/FCCSWGridPhiEta.h"
+#include "DetSegmentation/GridPhiEta.h"
 
 // DD4hep
 #include "DD4hep/DetFactoryHelper.h"
 #include "DD4hep/Segmentations.h"
-#include "DDSegmentation/BitField64.h"
+#include "DDSegmentation/BitFieldCoder.h"
+// Include GridPhiEta from dd4hep once eta calculation is fixed
+//#include "DDSegmentation/GridPhiEta.h"
 #include "DDSegmentation/CartesianGridXY.h"
 #include "DDSegmentation/CartesianGridXYZ.h"
 #include "DDSegmentation/PolarGridRPhi.h"
@@ -49,7 +51,7 @@ uint64_t cellID(const dd4hep::Segmentation& aSeg, const G4Step& aStep, bool aPre
  *   @param[in] aCellId ID of cell.
  *   return Vector of neighbours.
  */
-std::vector<uint64_t> neighbours(dd4hep::DDSegmentation::BitField64& aDecoder,
+std::vector<uint64_t> neighbours(const dd4hep::DDSegmentation::BitFieldCoder& aDecoder,
                                  const std::vector<std::string>& aFieldNames,
                                  const std::vector<std::pair<int, int>>& aFieldExtremes,
                                  uint64_t aCellId);
@@ -59,7 +61,7 @@ std::vector<uint64_t> neighbours(dd4hep::DDSegmentation::BitField64& aDecoder,
  *   @param[in] aFieldNames Names of the fields for which extremes are found.
  *   return Vector of pairs (min,max)
  */
-std::vector<std::pair<int, int>> bitfieldExtremes(dd4hep::DDSegmentation::BitField64& aDecoder,
+std::vector<std::pair<int, int>> bitfieldExtremes(const dd4hep::DDSegmentation::BitFieldCoder& aDecoder,
                                                   const std::vector<std::string>& aFieldNames);
 
 /** Get the half widths of the box envelope (TGeoBBox).

--- a/Detector/DetCommon/src/DetUtils.cpp
+++ b/Detector/DetCommon/src/DetUtils.cpp
@@ -52,29 +52,29 @@ uint64_t cellID(const dd4hep::Segmentation& aSeg, const G4Step& aStep, bool aPre
   return volID;
 }
 
-std::vector<uint64_t> neighbours(dd4hep::DDSegmentation::BitField64& aDecoder,
+std::vector<uint64_t> neighbours(const dd4hep::DDSegmentation::BitFieldCoder& aDecoder,
                                  const std::vector<std::string>& aFieldNames,
                                  const std::vector<std::pair<int, int>>& aFieldExtremes,
                                  uint64_t aCellId) {
   std::vector<uint64_t> neighbours;
-  aDecoder.setValue(aCellId);
+  dd4hep::DDSegmentation::CellID cID = aCellId;
   for (uint itField = 0; itField < aFieldNames.size(); itField++) {
     const auto& field = aFieldNames[itField];
-    int id = aDecoder[field];
+    CellID id = aDecoder.get(cID,field);
     if (id > aFieldExtremes[itField].first) {
-      aDecoder[field] = id - 1;
-      neighbours.emplace_back(aDecoder.getValue());
+      aDecoder.set(cID, field, id - 1);
+      neighbours.emplace_back(cID);
     }
     if (id < aFieldExtremes[itField].second) {
-      aDecoder[field] = id + 1;
-      neighbours.emplace_back(aDecoder.getValue());
+      aDecoder.set(cID, field, id + 1);
+      neighbours.emplace_back(cID);
     }
-    aDecoder[field] = id;
+    aDecoder.set(cID, field, id);
   }
   return std::move(neighbours);
 }
 
-std::vector<std::pair<int, int>> bitfieldExtremes(dd4hep::DDSegmentation::BitField64& aDecoder,
+std::vector<std::pair<int, int>> bitfieldExtremes(const dd4hep::DDSegmentation::BitFieldCoder& aDecoder,
                                                   const std::vector<std::string>& aFieldNames) {
   std::vector<std::pair<int, int>> extremes;
   int width = 0;

--- a/Detector/DetCommon/src/DetUtils.cpp
+++ b/Detector/DetCommon/src/DetUtils.cpp
@@ -60,7 +60,7 @@ std::vector<uint64_t> neighbours(const dd4hep::DDSegmentation::BitFieldCoder& aD
   dd4hep::DDSegmentation::CellID cID = aCellId;
   for (uint itField = 0; itField < aFieldNames.size(); itField++) {
     const auto& field = aFieldNames[itField];
-    CellID id = aDecoder.get(cID,field);
+    dd4hep::DDSegmentation::CellID id = aDecoder.get(cID,field);
     if (id > aFieldExtremes[itField].first) {
       aDecoder.set(cID, field, id - 1);
       neighbours.emplace_back(cID);

--- a/Detector/DetComponents/CMakeLists.txt
+++ b/Detector/DetComponents/CMakeLists.txt
@@ -20,7 +20,6 @@ gaudi_add_module(DetComponents
                  src/*.cpp
                  INCLUDE_DIRS GaudiKernel ROOT DD4hep Geant4 FWCore DetInterface DetSegmentation DetCommon ACTS
                  LINK_LIBRARIES GaudiKernel ROOT DD4hep ${DD4hep_COMPONENT_LIBRARIES} DetSegmentation DetCommon Geant4 FWCore ACTS::ACTSCore ACTS::ACTSDD4hepPlugin)
-
 include(CTest)
 gaudi_add_test(RedoSegmentationXYZ
                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/Detector/DetComponents/src/MergeLayers.cpp
+++ b/Detector/DetComponents/src/MergeLayers.cpp
@@ -16,8 +16,6 @@
 // STL
 #include <numeric>
 
-using dd4hep::DDSegmentation::CellID;
-
 DECLARE_ALGORITHM_FACTORY(MergeLayers)
 
 MergeLayers::MergeLayers(const std::string& aName, ISvcLocator* aSvcLoc) : GaudiAlgorithm(aName, aSvcLoc) {

--- a/Detector/DetComponents/src/RedoSegmentation.cpp
+++ b/Detector/DetComponents/src/RedoSegmentation.cpp
@@ -81,29 +81,28 @@ StatusCode RedoSegmentation::execute() {
   auto outHits = m_outHits.createAndPut();
   // loop over positioned hits to get the energy deposits: position and cellID
   // cellID contains the volumeID that needs to be copied to the new id
-  uint64_t oldid = 0;
+  dd4hep::DDSegmentation::CellID oldid = 0;
   uint debugIter = 0;
   for (const auto& hit : *inHits) {
     fcc::CaloHit newHit = outHits->create();
     newHit.energy(hit.energy());
     newHit.time(hit.time());
-    m_oldDecoder->setValue(hit.cellId());
+    dd4hep::DDSegmentation::CellID cellId = hit.cellId();
     if (debugIter < m_debugPrint) {
-      debug() << "OLD: " << m_oldDecoder->valueString() << endmsg;
+      debug() << "OLD: " << m_oldDecoder->valueString(cellId) << endmsg;
     }
     // factor 10 to convert mm to cm
     dd4hep::DDSegmentation::Vector3D position(hit.position().x / 10, hit.position().y / 10, hit.position().z / 10);
     // first calculate proper segmentation fields
-    uint64_t newcellId = m_segmentation->cellID(position, position, volumeID(hit.cellId()));
-    m_segmentation->decoder()->setValue(newcellId);
+    dd4hep::DDSegmentation::CellID newCellId = m_segmentation->cellID(position, position, volumeID(hit.cellId()));
     // now rewrite all other fields (detector ID)
     for (const auto& detectorField : m_detectorIdentifiers) {
-      oldid = (*m_oldDecoder)[detectorField];
-      (*m_segmentation->decoder())[detectorField] = oldid;
+      oldid = m_oldDecoder->get(cellId, detectorField);
+      m_segmentation->decoder()->set(newCellId, detectorField, oldid);
     }
-    newHit.cellId(m_segmentation->decoder()->getValue());
+    newHit.cellId(newCellId);
     if (debugIter < m_debugPrint) {
-      debug() << "NEW: " << m_segmentation->decoder()->valueString() << endmsg;
+      debug() << "NEW: " << m_segmentation->decoder()->valueString(newCellId) << endmsg;
       debugIter++;
     }
   }
@@ -115,9 +114,9 @@ StatusCode RedoSegmentation::finalize() {
    return GaudiAlgorithm::finalize(); }
 
 uint64_t RedoSegmentation::volumeID(uint64_t aCellId) const {
-  m_oldDecoder->setValue(aCellId);
+  dd4hep::DDSegmentation::CellID cID = aCellId;
   for (const auto& identifier : m_oldIdentifiers) {
-    (*m_oldDecoder)[identifier] = 0;
+    m_oldDecoder->set(cID, identifier, 0);
   }
-  return m_oldDecoder->getValue();
+  return cID;
 }

--- a/Detector/DetComponents/src/RedoSegmentation.h
+++ b/Detector/DetComponents/src/RedoSegmentation.h
@@ -75,7 +75,7 @@ private:
   /// Name of the new detector readout
   Gaudi::Property<std::string> m_newReadoutName{this, "newReadoutName", "", "Name of the new detector readout"};
   /// Old bitfield decoder
-  dd4hep::DDSegmentation::BitField64* m_oldDecoder;
+  dd4hep::DDSegmentation::BitFieldCoder* m_oldDecoder;
   /// Segmentation fields that are going to be replaced by the new segmentation
   Gaudi::Property<std::vector<std::string>> m_oldIdentifiers{
       this, "oldSegmentationIds", {}, "Segmentation fields that are going to be replaced by the new segmentation"};

--- a/Detector/DetComponents/src/RewriteBitfield.cpp
+++ b/Detector/DetComponents/src/RewriteBitfield.cpp
@@ -82,7 +82,7 @@ StatusCode RewriteBitfield::execute() {
     fcc::CaloHit newHit = outHits->create();
     newHit.energy(hit.energy());
     newHit.time(hit.time());
-    dd4hep::DDSegmentation::CellID = hit.cellId();
+    dd4hep::DDSegmentation::CellID cID = hit.cellId();
     if (debugIter < m_debugPrint) {
       debug() << "OLD: " << m_oldDecoder->valueString(cID) << endmsg;
     }

--- a/Detector/DetComponents/src/RewriteBitfield.cpp
+++ b/Detector/DetComponents/src/RewriteBitfield.cpp
@@ -82,18 +82,19 @@ StatusCode RewriteBitfield::execute() {
     fcc::CaloHit newHit = outHits->create();
     newHit.energy(hit.energy());
     newHit.time(hit.time());
-    m_oldDecoder->setValue(hit.cellId());
+    dd4hep::DDSegmentation::CellID = hit.cellId();
     if (debugIter < m_debugPrint) {
-      debug() << "OLD: " << m_oldDecoder->valueString() << endmsg;
+      debug() << "OLD: " << m_oldDecoder->valueString(cID) << endmsg;
     }
     // now rewrite all fields except for those to be removed
+    dd4hep::DDSegmentation::CellID newID=0;
     for (const auto& detectorField : m_detectorIdentifiers) {
-      oldid = (*m_oldDecoder)[detectorField];
-      (*m_newDecoder)[detectorField] = oldid;
+      oldid = m_oldDecoder->get(cID, detectorField);
+      m_newDecoder->set(newID, detectorField, oldid);
     }
-    newHit.cellId(m_newDecoder->getValue());
+    newHit.cellId(newID);
     if (debugIter < m_debugPrint) {
-      debug() << "NEW: " << m_newDecoder->valueString() << endmsg;
+      debug() << "NEW: " << m_newDecoder->valueString(newID) << endmsg;
       debugIter++;
     }
   }

--- a/Detector/DetComponents/src/RewriteBitfield.h
+++ b/Detector/DetComponents/src/RewriteBitfield.h
@@ -66,9 +66,9 @@ private:
   /// Name of the new detector readout
   Gaudi::Property<std::string> m_newReadoutName{this, "newReadoutName", "", "Name of the new detector readout"};
   /// Old bitfield decoder
-  dd4hep::DDSegmentation::BitField64* m_oldDecoder;
+  dd4hep::DDSegmentation::BitFieldCoder* m_oldDecoder;
   /// New bitfield decoder
-  dd4hep::DDSegmentation::BitField64* m_newDecoder;
+  dd4hep::DDSegmentation::BitFieldCoder* m_newDecoder;
   /// Segmentation fields that are going to be removed from the readout
   Gaudi::Property<std::vector<std::string>> m_oldIdentifiers{
       this, "removeIds", {}, "Segmentation fields that are going to be removed"};

--- a/Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_Common_upstream.xml
+++ b/Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_Common_upstream.xml
@@ -62,7 +62,7 @@
     <!-- readout for the reconstruction -->
     <!-- phi position is calculated based on the centre of volume (hence it cannot be done in the simulation from energy deposits position) -->
     <readout name="ECalBarrelPhiEta">
-      <segmentation type="GridPhiEta" grid_size_eta="0.01" phi_bins="704" offset_eta="-1.7723" offset_phi="-pi+(pi/704.)"/>
+      <segmentation type="FCCSWGridPhiEta" grid_size_eta="0.01" phi_bins="704" offset_eta="-1.7723" offset_phi="-pi+(pi/704.)"/>
       <id>system:4,cryo:1,type:3,subtype:3,layer:8,eta:9,phi:10</id>
     </readout>
   </readouts>

--- a/Detector/DetSegmentation/DetSegmentation/FCCSWGridPhiEta.h
+++ b/Detector/DetSegmentation/DetSegmentation/FCCSWGridPhiEta.h
@@ -19,7 +19,7 @@ public:
   /// default constructor using an arbitrary type
   FCCSWGridPhiEta(const std::string& aCellEncoding);
   /// Default constructor used by derived classes passing an existing decoder
-  FCCSWGridPhiEta(BitField64* decoder);
+  FCCSWGridPhiEta(BitFieldCoder* decoder);
 
   /// destructor
   virtual ~FCCSWGridPhiEta() = default;

--- a/Detector/DetSegmentation/DetSegmentation/FCCSWGridPhiEta.h
+++ b/Detector/DetSegmentation/DetSegmentation/FCCSWGridPhiEta.h
@@ -19,7 +19,7 @@ public:
   /// default constructor using an arbitrary type
   FCCSWGridPhiEta(const std::string& aCellEncoding);
   /// Default constructor used by derived classes passing an existing decoder
-  FCCSWGridPhiEta(BitFieldCoder* decoder);
+  FCCSWGridPhiEta(const BitFieldCoder* decoder);
 
   /// destructor
   virtual ~FCCSWGridPhiEta() = default;

--- a/Detector/DetSegmentation/DetSegmentation/GridEta.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridEta.h
@@ -21,7 +21,7 @@ public:
   /// default constructor using an arbitrary type
   GridEta(const std::string& aCellEncoding);
   /// Default constructor used by derived classes passing an existing decoder
-  GridEta(BitField64* decoder);
+  GridEta(const BitFieldCoder* decoder);
   /// destructor
   virtual ~GridEta() = default;
 

--- a/Detector/DetSegmentation/DetSegmentation/GridRPhiEta.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridRPhiEta.h
@@ -20,7 +20,7 @@ public:
   /// default constructor using an arbitrary type
   GridRPhiEta(const std::string& aCellEncoding);
   /// Default constructor used by derived classes passing an existing decoder
-  GridRPhiEta(BitField64* decoder);
+  GridRPhiEta(const BitFieldCoder* decoder);
   /// destructor
   virtual ~GridRPhiEta() = default;
 

--- a/Detector/DetSegmentation/src/FCCSWGridPhiEta.cpp
+++ b/Detector/DetSegmentation/src/FCCSWGridPhiEta.cpp
@@ -15,7 +15,7 @@ FCCSWGridPhiEta::FCCSWGridPhiEta(const std::string& cellEncoding) : GridEta(cell
   registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
 }
 
-FCCSWGridPhiEta::FCCSWGridPhiEta(BitField64* decoder) : GridEta(decoder) {
+FCCSWGridPhiEta::FCCSWGridPhiEta(const BitFieldCoder* decoder) : GridEta(decoder) {
   // define type and description
   _type = "FCCSWGridPhiEta";
   _description = "Phi-eta segmentation in the global coordinates";
@@ -28,31 +28,29 @@ FCCSWGridPhiEta::FCCSWGridPhiEta(BitField64* decoder) : GridEta(decoder) {
 
 /// determine the local based on the cell ID
 Vector3D FCCSWGridPhiEta::position(const CellID& cID) const {
-  _decoder->setValue(cID);
-  return positionFromREtaPhi(1.0, eta(), phi());
+  return positionFromREtaPhi(1.0, eta(cID), phi(cID));
 }
 
 /// determine the cell ID based on the position
 CellID FCCSWGridPhiEta::cellID(const Vector3D& /* localPosition */, const Vector3D& globalPosition,
                           const VolumeID& vID) const {
-  _decoder->setValue(vID);
+  CellID cID = vID;
   double lEta = etaFromXYZ(globalPosition);
   double lPhi = phiFromXYZ(globalPosition);
-  (*_decoder)[m_etaID] = positionToBin(lEta, m_gridSizeEta, m_offsetEta);
-  (*_decoder)[m_phiID] = positionToBin(lPhi, 2 * M_PI / (double)m_phiBins, m_offsetPhi);
-  return _decoder->getValue();
+  _decoder->set(cID, m_etaID, positionToBin(lEta, m_gridSizeEta, m_offsetEta));
+  _decoder->set(cID, m_phiID, positionToBin(lPhi, 2 * M_PI / (double)m_phiBins, m_offsetPhi));
+  return cID;
 }
 
 /// determine the azimuthal angle phi based on the current cell ID
-double FCCSWGridPhiEta::phi() const {
-  CellID phiValue = (*_decoder)[m_phiID].value();
-  return binToPosition(phiValue, 2. * M_PI / (double)m_phiBins, m_offsetPhi);
-}
+//double FCCSWGridPhiEta::phi() const {
+//  CellID phiValue = (*_decoder)[m_phiID].value();
+//  return binToPosition(phiValue, 2. * M_PI / (double)m_phiBins, m_offsetPhi);
+//}
 
 /// determine the azimuthal angle phi based on the cell ID
 double FCCSWGridPhiEta::phi(const CellID& cID) const {
-  _decoder->setValue(cID);
-  CellID phiValue = (*_decoder)[m_phiID].value();
+  CellID phiValue = _decoder->get(cID, m_phiID);
   return binToPosition(phiValue, 2. * M_PI / (double)m_phiBins, m_offsetPhi);
 }
 }

--- a/Detector/DetSegmentation/src/GridEta.cpp
+++ b/Detector/DetSegmentation/src/GridEta.cpp
@@ -15,7 +15,7 @@ GridEta::GridEta(const std::string& cellEncoding) : Segmentation(cellEncoding) {
   registerIdentifier("identifier_eta", "Cell ID identifier for eta", m_etaID, "eta");
 }
 
-GridEta::GridEta(BitField64* decoder) : Segmentation(decoder) {
+GridEta::GridEta(const BitFieldCoder* decoder) : Segmentation(decoder) {
   // define type and description
   _type = "GridEta";
   _description = "Eeta segmentation in the global coordinates";
@@ -28,28 +28,26 @@ GridEta::GridEta(BitField64* decoder) : Segmentation(decoder) {
 
 /// determine the local based on the cell ID
 Vector3D GridEta::position(const CellID& cID) const {
-  _decoder->setValue(cID);
-  return positionFromREtaPhi(1.0, eta(), 0.);
+  return positionFromREtaPhi(1.0, eta(cID), 0.);
 }
 
 /// determine the cell ID based on the position
 CellID GridEta::cellID(const Vector3D& /* localPosition */, const Vector3D& globalPosition, const VolumeID& vID) const {
-  _decoder->setValue(vID);
+  CellID cID = vID;
   double lEta = etaFromXYZ(globalPosition);
-  (*_decoder)[m_etaID] = positionToBin(lEta, m_gridSizeEta, m_offsetEta);
-  return _decoder->getValue();
+  _decoder->set(cID, m_etaID, positionToBin(lEta, m_gridSizeEta, m_offsetEta));
+  return cID;
 }
 
 /// determine the pseudorapidity based on the current cell ID
-double GridEta::eta() const {
-  CellID etaValue = (*_decoder)[m_etaID].value();
-  return binToPosition(etaValue, m_gridSizeEta, m_offsetEta);
-}
+//double GridEta::eta() const {
+//  CellID etaValue = (*_decoder)[m_etaID].value();
+//  return binToPosition(etaValue, m_gridSizeEta, m_offsetEta);
+//}
 
 /// determine the polar angle theta based on the cell ID
 double GridEta::eta(const CellID& cID) const {
-  _decoder->setValue(cID);
-  CellID etaValue = (*_decoder)[m_etaID].value();
+  CellID etaValue = _decoder->get(cID, m_etaID);
   return binToPosition(etaValue, m_gridSizeEta, m_offsetEta);
 }
 REGISTER_SEGMENTATION(GridEta)

--- a/Detector/DetSegmentation/src/GridRPhiEta.cpp
+++ b/Detector/DetSegmentation/src/GridRPhiEta.cpp
@@ -16,7 +16,7 @@ GridRPhiEta::GridRPhiEta(const std::string& cellEncoding) : FCCSWGridPhiEta(cell
   registerIdentifier("identifier_r", "Cell ID identifier for R", m_rID, "r");
 }
 
-GridRPhiEta::GridRPhiEta(BitField64* decoder) : FCCSWGridPhiEta(decoder) {
+GridRPhiEta::GridRPhiEta(const BitFieldCoder* decoder) : FCCSWGridPhiEta(decoder) {
   // define type and description
   _type = "GridRPhiEta";
   _description = "R-phi-eta segmentation in the global coordinates";
@@ -30,33 +30,31 @@ GridRPhiEta::GridRPhiEta(BitField64* decoder) : FCCSWGridPhiEta(decoder) {
 
 /// determine the local based on the cell ID
 Vector3D GridRPhiEta::position(const CellID& cID) const {
-  _decoder->setValue(cID);
-  return positionFromREtaPhi(r(), eta(), phi());
+  return positionFromREtaPhi(r(cID), eta(cID), phi(cID));
 }
 
 /// determine the cell ID based on the position
 CellID GridRPhiEta::cellID(const Vector3D& /* localPosition */, const Vector3D& globalPosition,
                            const VolumeID& vID) const {
-  _decoder->setValue(vID);
+  CellID cID = vID;
   double lRadius = radiusFromXYZ(globalPosition);
   double lEta = etaFromXYZ(globalPosition);
   double lPhi = phiFromXYZ(globalPosition);
-  (*_decoder)[m_etaID] = positionToBin(lEta, m_gridSizeEta, m_offsetEta);
-  (*_decoder)[m_phiID] = positionToBin(lPhi, 2 * M_PI / (double)m_phiBins, m_offsetPhi);
-  (*_decoder)[m_rID] = positionToBin(lRadius, m_gridSizeR, m_offsetR);
-  return _decoder->getValue();
+  _decoder->set(cID, m_etaID, positionToBin(lEta, m_gridSizeEta, m_offsetEta));
+  _decoder->set(cID, m_phiID, positionToBin(lPhi, 2 * M_PI / (double)m_phiBins, m_offsetPhi));
+  _decoder->set(cID, m_rID, positionToBin(lRadius, m_gridSizeR, m_offsetR));
+  return cID;
 }
 
 /// determine the radial distance R based on the current cell ID
-double GridRPhiEta::r() const {
-  CellID rValue = (*_decoder)[m_rID].value();
-  return binToPosition(rValue, m_gridSizeR, m_offsetR);
-}
+//double GridRPhiEta::r() const {
+//  CellID rValue = (*_decoder)[m_rID].value();
+//  return binToPosition(rValue, m_gridSizeR, m_offsetR);
+//}
 
 /// determine the radial distance R based on the cell ID
 double GridRPhiEta::r(const CellID& cID) const {
-  _decoder->setValue(cID);
-  CellID rValue = (*_decoder)[m_rID].value();
+  CellID rValue = _decoder->get(cID, m_rID);
   return binToPosition(rValue, m_gridSizeR, m_offsetR);
 }
 REGISTER_SEGMENTATION(GridRPhiEta)

--- a/Detector/DetSegmentation/src/plugins/SegmentationFactories.cpp
+++ b/Detector/DetSegmentation/src/plugins/SegmentationFactories.cpp
@@ -3,7 +3,7 @@
 
 namespace {
 template <typename T>
-dd4hep::SegmentationObject* create_segmentation(dd4hep::BitField64* decoder) {
+dd4hep::SegmentationObject* create_segmentation(const dd4hep::BitFieldCoder* decoder) {
   return new dd4hep::SegmentationWrapper<T>(decoder);
 }
 }

--- a/Detector/DetStudies/src/components/SamplingFractionInLayers.cpp
+++ b/Detector/DetStudies/src/components/SamplingFractionInLayers.cpp
@@ -89,15 +89,17 @@ StatusCode SamplingFractionInLayers::execute() {
 
   const auto deposits = m_deposits.get();
   for (const auto& hit : *deposits) {
-    decoder->setValue(hit.core().cellId);
-    sumElayers[(*decoder)[m_layerFieldName]] += hit.core().energy;
+    dd4hep::DDSegmentation::CellID cID = hit.core().cellId;
+    auto id = decoder->get(cID, m_layerFieldName);
+    sumElayers[id] += hit.core().energy;
     // check if energy was deposited in the calorimeter (active/passive material)
-    if ((*decoder)[m_layerFieldName] >= m_firstLayerId) {
+    if (id >= m_firstLayerId) {
       sumE += hit.core().energy;
       // active material of calorimeter
-      if ((*decoder)[m_activeFieldName] == m_activeFieldValue) {
+      auto activeField = decoder->get(cID, m_activeFieldName);
+      if (activeField == m_activeFieldValue) {
         sumEactive += hit.core().energy;
-        sumEactiveLayers[(*decoder)[m_layerFieldName]] += hit.core().energy;
+        sumEactiveLayers[id] += hit.core().energy;
       }
     }
   }

--- a/Detector/DetStudies/src/components/UpstreamMaterial.cpp
+++ b/Detector/DetStudies/src/components/UpstreamMaterial.cpp
@@ -81,9 +81,11 @@ StatusCode UpstreamMaterial::execute() {
   // get the energy deposited in the cryostat and in the detector (each layer)
   const auto deposits = m_deposits.get();
   for (const auto& hit : *deposits) {
-    decoder->setValue(hit.core().cellId);
-    if ((*decoder)["cryo"] == 0) {
-      sumEcells[(*decoder)[m_layerFieldName] - m_firstLayerId] += hit.core().energy;
+    dd4hep::DDSegmentation::CellID cID = hit.core().cellId;
+    const auto& field = "cryo";
+    int id = decoder->get(cID, field);
+    if (id == 0) {
+      sumEcells[id - m_firstLayerId] += hit.core().energy;
     } else {
       sumEupstream += hit.core().energy;
     }

--- a/Examples/src/InspectHitsCollectionsTool.cpp
+++ b/Examples/src/InspectHitsCollectionsTool.cpp
@@ -70,7 +70,7 @@ StatusCode InspectHitsCollectionsTool::saveOutput(const G4Event& aEvent) {
             if (hitC) {
               dd4hep::DDSegmentation::CellID cID = hitC->cellID;
               debug() << "hit Edep: " << hitC->energyDeposit << "\tcellID: " << cID << "\t"
-                      << decoder->valueString() << endmsg;
+                      << decoder->valueString(cID) << endmsg;
             }
           }
         }

--- a/Examples/src/InspectHitsCollectionsTool.cpp
+++ b/Examples/src/InspectHitsCollectionsTool.cpp
@@ -62,14 +62,14 @@ StatusCode InspectHitsCollectionsTool::saveOutput(const G4Event& aEvent) {
         for (size_t iter_hit = 0; iter_hit < n_hit; iter_hit++) {
           hitT = dynamic_cast<dd4hep::sim::Geant4TrackerHit*>(collect->GetHit(iter_hit));
           if (hitT) {
-            decoder->setValue(hitT->cellID);
-            debug() << "hit Edep: " << hitT->energyDeposit << "\tcellID: " << hitT->cellID << "\t"
-                    << decoder->valueString() << endmsg;
+            dd4hep::DDSegmentation::CellID cID = hitT->cellID;
+            debug() << "hit Edep: " << hitT->energyDeposit << "\tcellID: " << cID << "\t"
+                    << decoder->valueString(cID) << endmsg;
           } else {
             hitC = dynamic_cast<dd4hep::sim::Geant4CalorimeterHit*>(collect->GetHit(iter_hit));
             if (hitC) {
-              decoder->setValue(hitC->cellID);
-              debug() << "hit Edep: " << hitC->energyDeposit << "\tcellID: " << hitC->cellID << "\t"
+              dd4hep::DDSegmentation::CellID cID = hitC->cellID;
+              debug() << "hit Edep: " << hitC->energyDeposit << "\tcellID: " << cID << "\t"
                       << decoder->valueString() << endmsg;
             }
           }

--- a/Reconstruction/RecCalorimeter/src/components/CalibrateInLayersTool.cpp
+++ b/Reconstruction/RecCalorimeter/src/components/CalibrateInLayersTool.cpp
@@ -30,9 +30,9 @@ void CalibrateInLayersTool::calibrate(std::unordered_map<uint64_t, double>& aHit
   auto decoder = m_geoSvc->lcdd()->readout(m_readoutName).idSpec().decoder();
   // Loop through energy deposits, multiply energy to get cell energy at electromagnetic scale
   std::for_each(aHits.begin(), aHits.end(), [this, decoder](std::pair<const uint64_t, double>& p) {
-    decoder->setValue(p.first);
+    dd4hep::DDSegmentation::CellID cID = p.first;
     // shift layer id if the numbering does not start at 0
-    uint layer = (*decoder)[m_layerFieldName].value() - m_firstLayerId;
+    uint layer = decoder->get(cID, m_layerFieldName) - m_firstLayerId;
     if (layer < m_samplingFraction.size()) {
       p.second /= m_samplingFraction[layer];
     } else {

--- a/Reconstruction/RecCalorimeter/src/components/CaloTowerTool.cpp
+++ b/Reconstruction/RecCalorimeter/src/components/CaloTowerTool.cpp
@@ -164,7 +164,7 @@ uint CaloTowerTool::buildTowers(std::vector<std::vector<float>>& aTowers) {
     totalNumberOfCells += hcalExtBarrelCells->size();
   }
 
-  // 6. HCAL endcap calorimeter                                                                                                              
+  // 6. HCAL endcap calorimeter
   const fcc::CaloHitCollection* hcalEndcapCells = m_hcalEndcapCells.get();
   debug() << "Input Hcal endcap cell collection size: " << hcalEndcapCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers

--- a/Reconstruction/RecCalorimeter/src/components/CaloTowerTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/CaloTowerTool.h
@@ -148,10 +148,11 @@ private:
   Gaudi::Property<std::string> m_hcalEndcapReadoutName{this, "hcalEndcapReadoutName", "",
                                                        "name of the hcal endcap readout"};
   /// Name of the hcal forward calorimeter readout
-  Gaudi::Property<std::string> m_hcalFwdReadoutName{this, "hcalFwdReadoutName", "", 
+  Gaudi::Property<std::string> m_hcalFwdReadoutName{this, "hcalFwdReadoutName", "",
                                                     "name of the hcal fwd readout"};
   /// PhiEta segmentation of the electromagnetic barrel (owned by DD4hep)
   dd4hep::DDSegmentation::FCCSWGridPhiEta* m_ecalBarrelSegmentation;
+
   /// PhiEta segmentation of the ecal endcap calorimeter (owned by DD4hep)
   dd4hep::DDSegmentation::FCCSWGridPhiEta* m_ecalEndcapSegmentation;
   /// PhiEta segmentation of the ecal forward calorimeter (owned by DD4hep)

--- a/Reconstruction/RecCalorimeter/src/components/LayeredCaloTowerTool.cpp
+++ b/Reconstruction/RecCalorimeter/src/components/LayeredCaloTowerTool.cpp
@@ -45,7 +45,7 @@ StatusCode LayeredCaloTowerTool::initialize() {
   }
   // Take readout bitfield decoder from GeoSvc
   m_decoder =
-      std::shared_ptr<dd4hep::DDSegmentation::BitField64>(m_geoSvc->lcdd()->readout(m_readoutName).idSpec().decoder());
+      std::shared_ptr<dd4hep::DDSegmentation::BitFieldCoder>(m_geoSvc->lcdd()->readout(m_readoutName).idSpec().decoder());
   // check if decoder contains "layer"
   std::vector<std::string> fields;
   for (uint itField = 0; itField < m_decoder->size(); itField++) {
@@ -111,8 +111,8 @@ uint LayeredCaloTowerTool::buildTowers(std::vector<std::vector<float>>& aTowers)
     phiCellMin = m_segmentation->phi(cell.core().cellId) - M_PI / (double)m_segmentation->phiBins();
     phiCellMax = m_segmentation->phi(cell.core().cellId) + M_PI / (double)m_segmentation->phiBins();
     if (addLayerRestriction == true) {
-      m_decoder->setValue(cell.core().cellId);
-      layerCell = (*m_decoder)["layer"].value();
+      dd4hep::DDSegmentation::CellID cID = cell.core().cellId;
+      layerCell = m_decoder->get(cID, "layer");
       debug() << "Cell' layer = " << layerCell << endmsg;
     }
     iEtaMin = idEta(etaCellMin + epsilon);

--- a/Reconstruction/RecCalorimeter/src/components/LayeredCaloTowerTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/LayeredCaloTowerTool.h
@@ -116,7 +116,7 @@ public:
    * (in [0, m_nPhiTower) range)
    */
   uint phiNeighbour(int aIPhi) const;
-  std::shared_ptr<dd4hep::DDSegmentation::BitField64> m_decoder;
+  std::shared_ptr<dd4hep::DDSegmentation::BitFieldCoder> m_decoder;
 
 private:
   /// Handle for calo cells (input collection)

--- a/Reconstruction/RecCalorimeter/src/components/NestedVolumesCaloTool.cpp
+++ b/Reconstruction/RecCalorimeter/src/components/NestedVolumesCaloTool.cpp
@@ -40,8 +40,9 @@ StatusCode NestedVolumesCaloTool::prepareEmptyCells(std::unordered_map<uint64_t,
     return StatusCode::FAILURE;
   }
   // Get VolumeID
+  dd4hep::DDSegmentation::CellID cID = 0;
   for (unsigned int it = 0; it < m_fieldNames.size(); it++) {
-    (*decoder)[m_fieldNames[it]] = m_fieldValues[it];
+    decoder->set(cID, m_fieldNames[it], m_fieldValues[it]);
   }
   // Get the total number of given hierarchy of active volumes
   auto highestVol = gGeoManager->GetTopVolume();
@@ -90,11 +91,11 @@ StatusCode NestedVolumesCaloTool::prepareEmptyCells(std::unordered_map<uint64_t,
   do {
     index = 0;
     for (unsigned int it = 0; it < numVolTypes; it++) {
-      (*decoder)[numVolumesMap[it].first] = currentVol[it];
+      decoder->set(cID, numVolumesMap[it].first, currentVol[it]);
     }
-    aCells.insert(std::pair<uint64_t, double>(decoder->getValue(), 0));
+    aCells.insert(std::pair<uint64_t, double>(cID, 0));
     if (msgLevel() <= MSG::VERBOSE) {
-      verbose() << "Adding volume: " << decoder->valueString() << endmsg;
+      verbose() << "Adding volume: " << decoder->valueString(cID) << endmsg;
     }
     // get next volume iterators
     currentVol[index]++;

--- a/Reconstruction/RecCalorimeter/src/components/NoiseCaloCellsFromFileTool.cpp
+++ b/Reconstruction/RecCalorimeter/src/components/NoiseCaloCellsFromFileTool.cpp
@@ -139,8 +139,9 @@ double NoiseCaloCellsFromFileTool::getNoiseConstantPerCell(int64_t aCellId) {
   double cellEta = m_segmentation->eta(aCellId);
   // Take readout, bitfield from GeoSvc
   auto decoder = m_geoSvc->lcdd()->readout(m_readoutName).idSpec().decoder();
-  decoder->setValue(aCellId);
-  unsigned cellLayer = (*decoder)[m_activeFieldName];
+  //decoder->setValue(aCellId);
+  dd4hep::DDSegmentation::CellID cID = aCellId;
+  unsigned cellLayer = decoder->get(cID, m_activeFieldName);
 
   // All histograms have same binning, all bins with same size
   // Using the histogram in the first layer to get the bin size

--- a/Reconstruction/RecCalorimeter/src/components/TubeLayerPhiEtaCaloTool.cpp
+++ b/Reconstruction/RecCalorimeter/src/components/TubeLayerPhiEtaCaloTool.cpp
@@ -55,9 +55,9 @@ StatusCode TubeLayerPhiEtaCaloTool::prepareEmptyCells(std::unordered_map<uint64_
     error() << "There is no phi-eta segmentation!!!!" << endmsg;
     return StatusCode::FAILURE;
   }
-  info() << "FCCSWGridPhiEta: size in eta " << segmentation->gridSizeEta() << " , bins in phi " << segmentation->phiBins()
+  info() << "GridPhiEta: size in eta " << segmentation->gridSizeEta() << " , bins in phi " << segmentation->phiBins()
          << endmsg;
-  info() << "FCCSWGridPhiEta: offset in eta " << segmentation->offsetEta() << " , offset in phi "
+  info() << "GridPhiEta: offset in eta " << segmentation->offsetEta() << " , offset in phi "
          << segmentation->offsetPhi() << endmsg;
 
   // Take readout bitfield decoder from GeoSvc
@@ -71,24 +71,24 @@ StatusCode TubeLayerPhiEtaCaloTool::prepareEmptyCells(std::unordered_map<uint64_
   // Loop over active layers
   for (unsigned int ilayer = 0; ilayer < numLayers; ilayer++) {
     // Get VolumeID
+    dd4hep::DDSegmentation::VolumeID volumeID = 0;
     for (unsigned int it = 0; it < m_fieldNames.size(); it++) {
-      (*decoder)[m_fieldNames[it]] = m_fieldValues[it];
+      decoder->set(volumeID, m_fieldNames[it], m_fieldValues[it]);
     }
-    (*decoder)[m_activeFieldName] = ilayer;
-    (*decoder)["eta"] = 0;
-    (*decoder)["phi"] = 0;
-    uint64_t volumeId = decoder->getValue();
+    decoder->set(volumeID, m_activeFieldName, ilayer);
+    decoder->set(volumeID, "eta", 0);
+    decoder->set(volumeID, "phi", 0);
 
     // Get number of segmentation cells within the active volume
-    auto numCells = det::utils::numberOfCells(volumeId, *segmentation);
+    auto numCells = det::utils::numberOfCells(volumeID, *segmentation);
     debug() << "Segmentation cells  (Nphi, Neta, minEta): " << numCells << endmsg;
     // Loop over segmenation cells
     for (unsigned int iphi = 0; iphi < numCells[0]; iphi++) {
       for (unsigned int ieta = 0; ieta < numCells[1]; ieta++) {
-        (*decoder)["phi"] = iphi;
-        (*decoder)["eta"] = ieta + numCells[2]; // start from the minimum existing eta cell in this layer
-        uint64_t cellId = decoder->getValue();
-        aCells.insert(std::pair<uint64_t, double>(cellId, 0));
+        decoder->set(volumeID, "phi", iphi);
+        decoder->set(volumeID, "eta", ieta + numCells[2]); // start from the minimum existing eta cell in this layer
+        dd4hep::DDSegmentation::CellID cellId = volumeID;
+        aCells.insert(std::pair<dd4hep::DDSegmentation::CellID, double>(cellId, 0));
       }
     }
   }

--- a/Reconstruction/RecCalorimeter/src/components/TubeLayerPhiEtaCaloTool.cpp
+++ b/Reconstruction/RecCalorimeter/src/components/TubeLayerPhiEtaCaloTool.cpp
@@ -55,9 +55,9 @@ StatusCode TubeLayerPhiEtaCaloTool::prepareEmptyCells(std::unordered_map<uint64_
     error() << "There is no phi-eta segmentation!!!!" << endmsg;
     return StatusCode::FAILURE;
   }
-  info() << "GridPhiEta: size in eta " << segmentation->gridSizeEta() << " , bins in phi " << segmentation->phiBins()
+  info() << "FCCSWGridPhiEta: size in eta " << segmentation->gridSizeEta() << " , bins in phi " << segmentation->phiBins()
          << endmsg;
-  info() << "GridPhiEta: offset in eta " << segmentation->offsetEta() << " , offset in phi "
+  info() << "FCCSWGridPhiEta: offset in eta " << segmentation->offsetEta() << " , offset in phi "
          << segmentation->offsetPhi() << endmsg;
 
   // Take readout bitfield decoder from GeoSvc

--- a/Reconstruction/RecTracker/RecTracker/TrackingUtils.h
+++ b/Reconstruction/RecTracker/RecTracker/TrackingUtils.h
@@ -5,7 +5,7 @@
 
 namespace dd4hep {
   namespace DDSegmentation {
-    class BitField64;
+    class BitFieldCoder;
   }
 }
 
@@ -16,7 +16,7 @@ namespace fcc {
 
 namespace rec {
 /// fill vector with hits ordered according to the CellIdOrder struct
-void sortTrackHits(const fcc::TrackHitCollection* unsortedHits, std::vector<fcc::TrackHit>& sortedHits, dd4hep::DDSegmentation::BitField64* decoder);
+void sortTrackHits(const fcc::TrackHitCollection* unsortedHits, std::vector<fcc::TrackHit>& sortedHits, const dd4hep::DDSegmentation::BitFieldCoder* decoder);
 
 }
 #endif

--- a/Reconstruction/RecTracker/src/components/CombinatorialSeedingTest.cpp
+++ b/Reconstruction/RecTracker/src/components/CombinatorialSeedingTest.cpp
@@ -7,7 +7,7 @@
 
 #include "DD4hep/Detector.h"
 #include "DD4hep/Volumes.h"
-#include "DDRec/API/IDDecoder.h"
+//#include "DDRec/API/IDDecoder.h"
 #include "DDSegmentation/BitField64.h"
 #include "DDSegmentation/CartesianGridXZ.h"
 

--- a/Reconstruction/RecTracker/src/components/ExtrapolationTest.cpp
+++ b/Reconstruction/RecTracker/src/components/ExtrapolationTest.cpp
@@ -29,7 +29,7 @@
 
 #include "DD4hep/Detector.h"
 #include "DD4hep/Volumes.h"
-#include "DDRec/API/IDDecoder.h"
+//#include "DDRec/API/IDDecoder.h"
 #include "DDSegmentation/BitField64.h"
 
 #include <cmath>
@@ -97,7 +97,7 @@ StatusCode ExtrapolationTest::execute() {
   ActsVector<ParValue_t, NGlobalPars> pars;
   pars << 0, // local coordinate 1
           0, // local coordinate 2
-          m_flatDist() * M_PI * 0.5, // phi 
+          m_flatDist() * M_PI * 0.5, // phi
           m_flatDist() * M_PI*0.45,  // theta
           0.001; // qOverP
   auto startCov =

--- a/Test/TestReconstruction/CMakeLists.txt
+++ b/Test/TestReconstruction/CMakeLists.txt
@@ -6,6 +6,8 @@ gaudi_subdir(TestReconstruction v1r0)
 gaudi_depends_on_subdirs(GaudiAlg GaudiKernel FWCore Detector/DetInterface Detector/DetCommon Detector/DetSegmentation)
 find_package(Geant4)
 find_package(ACTS COMPONENTS Core)
+find_package(DD4hep)
+
 include(${Geant4_USE_FILE})
 
 gaudi_add_module(TestTestPlugins

--- a/Test/TestReconstruction/src/CompareTrackHitPositionAndCellId.cpp
+++ b/Test/TestReconstruction/src/CompareTrackHitPositionAndCellId.cpp
@@ -60,21 +60,21 @@ StatusCode CompareTrackHitPositionAndCellId::execute() {
   double fcc_l1 = 0;
   double fcc_l2 = 0;
   // expect position from cellID to deviate at most two cell sizes from true energy deposit
-  // use largest cell for simplicity 
+  // use largest cell for simplicity
   double l_tolerance = 1 * Gaudi::Units::mm;
     for (auto hit : (*hits)) {
-    long long int theCellId = hit.core().cellId;
+    dd4hep::DDSegmentation::CellID theCellId = hit.core().cellId;
     debug() << theCellId << endmsg;
-    m_decoderBarrel->setValue(theCellId);
-    int system_id = (*m_decoderBarrel)["system"];
+    auto field = "system";
+    int system_id = m_decoderBarrel->get(theCellId, field);
     if (system_id == 0 || system_id == 1) {
 
       auto detelement = volman.lookupDetElement(theCellId);
       debug() << "volIDfromDetElement: " << detelement.volumeID() << endmsg;
       const auto& transformMatrix = detelement.nominal().worldTransformation();
       double outGlobal[3] {0,0,0};
-      fcc_l1 = (*m_decoderBarrel)["x"] * l_segGridSizeXBarrel;
-      fcc_l2 = (*m_decoderBarrel)["z"] * l_segGridSizeZBarrel;
+      fcc_l1 = m_decoderBarrel->get(theCellId, "x") * l_segGridSizeXBarrel;
+      fcc_l2 = m_decoderBarrel->get(theCellId, "z") * l_segGridSizeZBarrel;
       double inLocal[] = {fcc_l1, 0, fcc_l2};
       transformMatrix.LocalToMaster(inLocal, outGlobal);
       auto edmPos = fcc::Point();
@@ -83,9 +83,9 @@ StatusCode CompareTrackHitPositionAndCellId::execute() {
       edmPos.z = outGlobal[2] / dd4hep::mm;
 
       debug() << " hit in system: " << system_id;
-      int layer_id = (*m_decoderBarrel)["layer"];
+      int layer_id = m_decoderBarrel->get(theCellId, "layer");
       debug() << "\t layer " << layer_id;
-      int module_id = (*m_decoderBarrel)["module"];
+      int module_id = m_decoderBarrel->get(theCellId,"module");
       debug() << "\t module " << module_id;
       debug() << endmsg;
 
@@ -100,20 +100,19 @@ StatusCode CompareTrackHitPositionAndCellId::execute() {
       }
 
     } else if (system_id == 2 || system_id == 3 || system_id == 4) {
-      m_decoderEndcap->setValue(theCellId);
-      int posneg_id = (*m_decoderEndcap)["posneg"];
+      int posneg_id = m_decoderEndcap->get(theCellId,"posneg");
       debug() << "\t posneg " << posneg_id;
-      int layer_id = (*m_decoderEndcap)["disc"];
+      int layer_id = m_decoderEndcap->get(theCellId,"disc");
       debug() << "\t disc " << layer_id;
-      int module_id = (*m_decoderEndcap)["component"];
+      int module_id = m_decoderEndcap->get(theCellId,"component");
       debug() << "\t module " << module_id;
       debug() << endmsg;
-      auto detelement = volman.lookupDetElement((*m_decoderEndcap).getValue());
+      auto detelement = volman.lookupDetElement(theCellId);
       debug() << "volId from Detelement: " << detelement.volumeID() << endmsg;
       const auto& transformMatrix = detelement.nominal().worldTransformation();
       double outGlobal[3] {0, 0, 0};
-      fcc_l1 = (*m_decoderEndcap)["x"] * l_segGridSizeXEndcap;
-      fcc_l2 = (*m_decoderEndcap)["z"] * l_segGridSizeZEndcap;
+      fcc_l1 = m_decoderEndcap->get(theCellId, "x") * l_segGridSizeXEndcap;
+      fcc_l2 = m_decoderEndcap->get(theCellId, "z") * l_segGridSizeZEndcap;
       double inLocal[] = {fcc_l1, 0, fcc_l2};
       transformMatrix.LocalToMaster(inLocal, outGlobal);
       auto edmPos = fcc::Point();

--- a/Test/TestReconstruction/src/TestCellCounting.cpp
+++ b/Test/TestReconstruction/src/TestCellCounting.cpp
@@ -43,13 +43,15 @@ StatusCode TestCellCounting::initialize() {
     error() << "Size of names and values is not the same" << endmsg;
     return StatusCode::FAILURE;
   }
+
+  dd4hep::DDSegmentation::CellID cID = 0;
   for (uint it = 0; it < m_fieldNames.size(); it++) {
-    (*decoder)[m_fieldNames[it]] = m_fieldValues[it];
+      decoder->set(cID, m_fieldNames[it], m_fieldValues[it]);
   }
-  m_volumeId = decoder->getValue();
+  m_volumeId = cID;
 
   // count the segmentation cells for the volume
-  info() << "Counting cells for volume " << decoder->valueString() << " -> volume ID: " << m_volumeId << endmsg;
+  info() << "Counting cells for volume " << decoder->valueString(cID) << " -> volume ID: " << m_volumeId << endmsg;
   auto segmentationXY = dynamic_cast<dd4hep::DDSegmentation::CartesianGridXY*>(
       m_geoSvc->lcdd()->readout(m_readoutName).segmentation().segmentation());
   if (segmentationXY == nullptr) {

--- a/Test/TestReconstruction/src/TestNeighbours.h
+++ b/Test/TestReconstruction/src/TestNeighbours.h
@@ -13,7 +13,7 @@ class IGeoSvc;
 // DD4hep
 namespace dd4hep {
 namespace DDSegmentation {
-class BitField64;
+class BitFieldCoder;
 }
 }
 
@@ -54,7 +54,7 @@ private:
   /// Name of the detector readout
   Gaudi::Property<std::string> m_readoutName{this, "readout", "", "Name of the detector readout"};
   /// Pointer to the bitfield decoder
-  dd4hep::DDSegmentation::BitField64* m_decoder;
+  const dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
   /// Names of the fields for which neighbours are found
   std::vector<std::string> m_fieldNames;
   /// Minimal and maximal values of the fields for which neighbours are found

--- a/init.sh
+++ b/init.sh
@@ -4,4 +4,4 @@
 export FCCSWBASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 weekday=`date +%a`
 
-source /cvmfs/fcc.cern.ch/sw/views/nightlies/Wed/x86_64-slc6-gcc62-opt/setup.sh
+source /cvmfs/fcc.cern.ch/sw/views/releases/externals/93.0.0/x86_64-slc6-gcc62-opt/setup.sh

--- a/init.sh
+++ b/init.sh
@@ -3,4 +3,5 @@
 # set FCCSWBASEDIR to the directory containing this script
 export FCCSWBASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 weekday=`date +%a`
-source /cvmfs/fcc.cern.ch/sw/views/releases/0.9.1/x86_64-slc6-gcc62-opt/setup.sh
+
+source /cvmfs/fcc.cern.ch/sw/views/nightlies/Wed/x86_64-slc6-gcc62-opt/setup.sh


### PR DESCRIPTION
Addresses a compatibility problem building against `DD4hep-1.05` due to `BitField64*`.

Changes proposed in this pull-request:

- Replace `BitField64` with the new threadsafe class `BitFieldCoder`.
- Keep using our implementation for segmentations (`GridEta`, `GridPhiEta` - previously renamed `FCCSWGridPhiEta` - , `GridRPhiEta`) since `DD4hep` has a bug calculating `eta` which causes failures in our tests. 

To be done **before merging this PR**:
- [x] Modify `init.sh` to source a stable stack of externals
- [x] Release a new version of the externals 
   + Done, new externals build against `LCG_93`

To be done **in a different PR**:

- [ ] Replace all our segmentations with the ones provided by DD4hep.
- [ ] PR to Include `GridEta` in DD4hep
- [x] PR to fix the `eta` calculation in `DD4hep` 