### PR TITLE
Smear vertices in G4

### DIFF
--- a/Sim/SimG4Components/src/SimG4SingleParticleGeneratorTool.cpp
+++ b/Sim/SimG4Components/src/SimG4SingleParticleGeneratorTool.cpp
@@ -79,7 +79,9 @@ G4Event* SimG4SingleParticleGeneratorTool::g4Event() {
   double randomZ = std::cos(theta);
 
   G4ThreeVector particleDir = G4ThreeVector(randomX, randomY, randomZ);
-  G4ThreeVector particlePosition = G4ThreeVector(m_vertexX, m_vertexY, m_vertexZ);
+  G4ThreeVector particlePosition = G4ThreeVector(CLHEP::RandFlat::shoot(-m_vertexX,m_vertexX),
+                                                 CLHEP::RandFlat::shoot(-m_vertexY, m_vertexY),
+                                                 CLHEP::RandFlat::shoot(-m_vertexZ, m_vertexZ));
 
   G4PrimaryVertex* vertex = new G4PrimaryVertex(particlePosition, 0.);
   G4PrimaryParticle* part = new G4PrimaryParticle(particleDef);

--- a/Sim/SimG4Components/src/SimG4SingleParticleGeneratorTool.cpp
+++ b/Sim/SimG4Components/src/SimG4SingleParticleGeneratorTool.cpp
@@ -79,7 +79,7 @@ G4Event* SimG4SingleParticleGeneratorTool::g4Event() {
   double randomZ = std::cos(theta);
 
   G4ThreeVector particleDir = G4ThreeVector(randomX, randomY, randomZ);
-  G4ThreeVector particlePosition = G4ThreeVector(CLHEP::RandFlat::shoot(-m_vertexX,m_vertexX),
+  G4ThreeVector particlePosition = G4ThreeVector(CLHEP::RandFlat::shoot(-m_vertexX, m_vertexX),
                                                  CLHEP::RandFlat::shoot(-m_vertexY, m_vertexY),
                                                  CLHEP::RandFlat::shoot(-m_vertexZ, m_vertexZ));
 


### PR DESCRIPTION
Changes proposed in this pull-request:

- position of vertex in G4 particle gun is used as a width of the distribution, not as an exact value 