### PR TITLE
DigiTrackerHits-Merger

### DIFF
--- a/FWCore/src/components/PileupDigiTrackHitMergeTool.cpp
+++ b/FWCore/src/components/PileupDigiTrackHitMergeTool.cpp
@@ -3,6 +3,8 @@
 #include "podio/EventStore.h"
 
 #include "datamodel/DigiTrackHitAssociationCollection.h"
+#include "datamodel/MCParticle.h"
+#include "datamodel/MCParticleCollection.h"
 #include "datamodel/PositionedTrackHitCollection.h"
 #include "datamodel/TrackHitCollection.h"
 
@@ -15,8 +17,10 @@ PileupDigiTrackHitMergeTool::PileupDigiTrackHitMergeTool(const std::string& aTyp
   declareInterface<IEDMMergeTool>(this);
   declareProperty("signalPositionedHits", m_hitsSignal);
   declareProperty("signalDigiHits", m_posHitsSignal);
+  declareProperty("signalParticles", m_particlesSignal);
   declareProperty("mergedPositionedHits", m_hitsMerged);
   declareProperty("mergedDigiHits", m_digiHitsMerged);
+  declareProperty("mergedParticles", m_particlesMerged);
 }
 
 StatusCode PileupDigiTrackHitMergeTool::initialize() { return StatusCode::SUCCESS; }
@@ -27,6 +31,7 @@ StatusCode PileupDigiTrackHitMergeTool::readPileupCollection(podio::EventStore& 
   // local pointers, to be filled by the event store
   const fcc::PositionedTrackHitCollection* hitCollection;
   const fcc::DigiTrackHitAssociationCollection* digiHitCollection;
+  const fcc::MCParticleCollection* particleCollection;
 
   // get collection address and store it in container
   bool hitCollectionPresent = store.get(m_pileupHitsBranchName, hitCollection);
@@ -40,10 +45,21 @@ StatusCode PileupDigiTrackHitMergeTool::readPileupCollection(podio::EventStore& 
   /// as above, for the positioned collection
   bool digiHitCollectionPresent = store.get(m_pileupPosHitsBranchName, digiHitCollection);
   if (digiHitCollectionPresent) {
-    m_digiTrackHitsCollection.push_back(digiHitCollection);
+    m_digiTrackHitsCollections.push_back(digiHitCollection);
   } else {
     warning() << "No collection could be read from branch " << m_pileupPosHitsBranchName << endmsg;
     return StatusCode::FAILURE;
+  }
+
+  /// as above, for the particle collection (if wanted)
+  if (m_mergeParticles) {
+    bool particleCollectionPresent = store.get(m_pileupParticleBranchName, particleCollection);
+    if (particleCollectionPresent) {
+      m_particleCollections.push_back(particleCollection);
+    } else {
+      warning() << "No collection could be read from branch " << m_pileupParticleBranchName << endmsg;
+      return StatusCode::FAILURE;
+    }
   }
 
   return StatusCode::SUCCESS;
@@ -53,10 +69,14 @@ StatusCode PileupDigiTrackHitMergeTool::readSignal() {
   // get collection from event store
   auto collHitsSig = m_hitsSignal.get();
   auto collPosHitsSig = m_posHitsSignal.get();
-
+  auto collPartSig = m_particlesSignal.get();
   // store them in internal container
   m_hitCollections.push_back(collHitsSig);
-  m_digiTrackHitsCollection.push_back(collPosHitsSig);
+  m_digiTrackHitsCollections.push_back(collPosHitsSig);
+  // check if particles should be merged
+  if (m_mergeParticles) {
+    m_particleCollections.push_back(collPartSig);
+  }
 
   return StatusCode::SUCCESS;
 }
@@ -66,12 +86,14 @@ StatusCode PileupDigiTrackHitMergeTool::mergeCollections() {
   // ownership given to data service at end of execute
   fcc::PositionedTrackHitCollection* collHitsMerged = new fcc::PositionedTrackHitCollection();
   fcc::DigiTrackHitAssociationCollection* collDigiHitsMerged = new fcc::DigiTrackHitAssociationCollection();
+  fcc::MCParticleCollection* collParticlesMerged = new fcc::MCParticleCollection();
 
   unsigned int collectionCounter = 0;
-  for (size_t j = 0; j < m_digiTrackHitsCollection.size(); j++) {
-    auto digiHitColl = m_digiTrackHitsCollection.at(j);
+  for (size_t j = 0; j < m_digiTrackHitsCollections.size(); j++) {
+    auto offset = collectionCounter * m_trackIDCollectionOffset;
+    auto digiHitColl = m_digiTrackHitsCollections.at(j);
     auto hitColl = m_hitCollections.at(j);
-    for (size_t i = 0; i < digiHitColl->size(); i++) {
+    for (int i = 0; i < digiHitColl->size(); i++) {
       auto clon = hitColl->at(i).clone();
       // add pileup vertex counter with an offset
       // i.e. for the signal event, 'bits' is just the trackID taken from geant
@@ -82,19 +104,35 @@ StatusCode PileupDigiTrackHitMergeTool::mergeCollections() {
         error() << " The offset width or trackID field size needs to be adjusted!" << endmsg;
         return StatusCode::FAILURE;
       }
-
-      clon.bits(clon.bits() + collectionCounter * m_trackIDCollectionOffset);
+      clon.bits(clon.bits() + offset);
       auto newDigiHit = digiHitColl->at(i).clone();
       newDigiHit.hit(clon);
       collHitsMerged->push_back(clon);
       collDigiHitsMerged->push_back(newDigiHit);
     }
+    if (m_mergeParticles) {
+      auto partColl = m_particleCollections.at(j);
+      for (int i = 0; i < partColl->size(); i++) {
+        auto clonParticle = partColl->at(i).clone();
+        if (partColl->at(i).bits() > m_trackIDCollectionOffset) {
+          std::cout << "bits: " << hitColl->at(i).bits() << ", offset: " << m_trackIDCollectionOffset << std::endl;
+          error() << "Event contains too many tracks to guarantee a unique trackID";
+          error() << " The offset width or trackID field size needs to be adjusted _ particles!" << endmsg;
+          return StatusCode::FAILURE;
+        }
+        clonParticle.bits(clonParticle.bits() + offset);
+        collParticlesMerged->push_back(clonParticle);
+      }
+    }
     ++collectionCounter;
   }
   m_hitsMerged.put(collHitsMerged);
   m_digiHitsMerged.put(collDigiHitsMerged);
+  m_particlesMerged.put(collParticlesMerged);
 
   m_hitCollections.clear();
-  m_digiTrackHitsCollection.clear();
+  m_digiTrackHitsCollections.clear();
+  m_particleCollections.clear();
+
   return StatusCode::SUCCESS;
 }

--- a/FWCore/src/components/PileupDigiTrackHitMergeTool.cpp
+++ b/FWCore/src/components/PileupDigiTrackHitMergeTool.cpp
@@ -1,0 +1,100 @@
+#include "PileupDigiTrackHitMergeTool.h"
+
+#include "podio/EventStore.h"
+
+#include "datamodel/DigiTrackHitAssociationCollection.h"
+#include "datamodel/PositionedTrackHitCollection.h"
+#include "datamodel/TrackHitCollection.h"
+
+DECLARE_TOOL_FACTORY(PileupDigiTrackHitMergeTool)
+DECLARE_COMPONENT_WITH_ID(PileupDigiTrackHitMergeTool, "PileupDigiTrackHitMergeTool")
+
+PileupDigiTrackHitMergeTool::PileupDigiTrackHitMergeTool(const std::string& aType, const std::string& aName,
+                                                         const IInterface* aParent)
+    : GaudiTool(aType, aName, aParent) {
+  declareInterface<IEDMMergeTool>(this);
+  declareProperty("signalPositionedHits", m_hitsSignal);
+  declareProperty("signalDigiHits", m_posHitsSignal);
+  declareProperty("mergedPositionedHits", m_hitsMerged);
+  declareProperty("mergedDigiHits", m_digiHitsMerged);
+}
+
+StatusCode PileupDigiTrackHitMergeTool::initialize() { return StatusCode::SUCCESS; }
+
+StatusCode PileupDigiTrackHitMergeTool::finalize() { return StatusCode::SUCCESS; }
+
+StatusCode PileupDigiTrackHitMergeTool::readPileupCollection(podio::EventStore& store) {
+  // local pointers, to be filled by the event store
+  const fcc::PositionedTrackHitCollection* hitCollection;
+  const fcc::DigiTrackHitAssociationCollection* digiHitCollection;
+
+  // get collection address and store it in container
+  bool hitCollectionPresent = store.get(m_pileupHitsBranchName, hitCollection);
+  if (hitCollectionPresent) {
+    m_hitCollections.push_back(hitCollection);
+  } else {
+    warning() << "No collection could be read from branch " << m_pileupHitsBranchName << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  /// as above, for the positioned collection
+  bool digiHitCollectionPresent = store.get(m_pileupPosHitsBranchName, digiHitCollection);
+  if (digiHitCollectionPresent) {
+    m_digiTrackHitsCollection.push_back(digiHitCollection);
+  } else {
+    warning() << "No collection could be read from branch " << m_pileupPosHitsBranchName << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode PileupDigiTrackHitMergeTool::readSignal() {
+  // get collection from event store
+  auto collHitsSig = m_hitsSignal.get();
+  auto collPosHitsSig = m_posHitsSignal.get();
+
+  // store them in internal container
+  m_hitCollections.push_back(collHitsSig);
+  m_digiTrackHitsCollection.push_back(collPosHitsSig);
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode PileupDigiTrackHitMergeTool::mergeCollections() {
+
+  // ownership given to data service at end of execute
+  fcc::PositionedTrackHitCollection* collHitsMerged = new fcc::PositionedTrackHitCollection();
+  fcc::DigiTrackHitAssociationCollection* collDigiHitsMerged = new fcc::DigiTrackHitAssociationCollection();
+
+  unsigned int collectionCounter = 0;
+  for (size_t j = 0; j < m_digiTrackHitsCollection.size(); j++) {
+    auto digiHitColl = m_digiTrackHitsCollection.at(j);
+    auto hitColl = m_hitCollections.at(j);
+    for (size_t i = 0; i < digiHitColl->size(); i++) {
+      auto clon = hitColl->at(i).clone();
+      // add pileup vertex counter with an offset
+      // i.e. for the signal event, 'bits' is just the trackID taken from geant
+      // for the n-th pileup event, 'bits' is the trackID + n * offset
+      // offset needs to be big enough to ensure uniqueness of trackID
+      if (hitColl->at(i).bits() > m_trackIDCollectionOffset) {
+        error() << "Event contains too many tracks to guarantee a unique trackID";
+        error() << " The offset width or trackID field size needs to be adjusted!" << endmsg;
+        return StatusCode::FAILURE;
+      }
+
+      clon.bits(clon.bits() + collectionCounter * m_trackIDCollectionOffset);
+      auto newDigiHit = digiHitColl->at(i).clone();
+      newDigiHit.hit(clon);
+      collHitsMerged->push_back(clon);
+      collDigiHitsMerged->push_back(newDigiHit);
+    }
+    ++collectionCounter;
+  }
+  m_hitsMerged.put(collHitsMerged);
+  m_digiHitsMerged.put(collDigiHitsMerged);
+
+  m_hitCollections.clear();
+  m_digiTrackHitsCollection.clear();
+  return StatusCode::SUCCESS;
+}

--- a/FWCore/src/components/PileupDigiTrackHitMergeTool.h
+++ b/FWCore/src/components/PileupDigiTrackHitMergeTool.h
@@ -13,11 +13,13 @@ class PositionedTrackHit;
 class PositionedTrackHitCollection;
 class DigiTrackHitAssociation;
 class DigiTrackHitAssociationCollection;
+class MCParticle;
+class MCParticleCollection;
 }
 
 /** @class PileupDigiTrackHitMergeTool
  *
- * Implemenation of the MergeTool for Digitization hits.
+ * Implemenation of the MergeTool for Digitization hits and, if requested, simulated hits.
  * While merging, this algorithm tries to keep the trackIDs unique by adding the pileup event number with an offset.
  * This should be transparent, but the trackIDs will be non-consecutive.
  *
@@ -50,25 +52,39 @@ private:
   Gaudi::Property<std::string> m_pileupPosHitsBranchName{this, "pileupDigiHitsBranch", "digiHits",
                                                          "Name of the branch from which to read pileup collection"};
 
+  /// Name of the branch from which to read pileup collection
+  Gaudi::Property<std::string> m_pileupParticleBranchName{this, "pileupParticleBranch", "simParticles",
+                                                          "Name of the branch from which to read pileup collection"};
+
+  /// Flag indicating if particles are present and should be merged
+  Gaudi::Property<bool> m_mergeParticles{this, "mergeParticles", false,
+                                         "Flag indicating if particles are present and should be merged"};
+
   /// internal container to keep of collections to be merged
   std::vector<const fcc::PositionedTrackHitCollection*> m_hitCollections;
   /// internal container to keep of collections to be merged
-  std::vector<const fcc::DigiTrackHitAssociationCollection*> m_digiTrackHitsCollection;
+  std::vector<const fcc::DigiTrackHitAssociationCollection*> m_digiTrackHitsCollections;
+  /// internal container to keep of collections to be merge
+  std::vector<const fcc::MCParticleCollection*> m_particleCollections;
 
   /// Output of this tool: merged collection
   DataHandle<fcc::PositionedTrackHitCollection> m_hitsMerged{"overlay/hits", Gaudi::DataHandle::Writer, this};
   /// Output of this tool: merged collection
   DataHandle<fcc::DigiTrackHitAssociationCollection> m_digiHitsMerged{"overlay/digiHits", Gaudi::DataHandle::Writer,
                                                                       this};
+  /// Output of this tool: merged collection
+  DataHandle<fcc::MCParticleCollection> m_particlesMerged{"overlay/particles", Gaudi::DataHandle::Writer, this};
 
   /// input to this tool: signal collection
   DataHandle<fcc::PositionedTrackHitCollection> m_hitsSignal{"overlay/signalHits", Gaudi::DataHandle::Reader, this};
   /// input to this tool: signal collection
   DataHandle<fcc::DigiTrackHitAssociationCollection> m_posHitsSignal{"overlay/signalDigiHits",
                                                                      Gaudi::DataHandle::Reader, this};
+  /// input to this tool: signal collection
+  DataHandle<fcc::MCParticleCollection> m_particlesSignal{"overlay/signalParticles", Gaudi::DataHandle::Reader, this};
 
   /// offset with which the pileup event number is added to the trackID
-  const unsigned int m_trackIDCollectionOffset = 2 << 20;
+  const unsigned int m_trackIDCollectionOffset = 2.5e6;
 };
 
 #endif  // FWCORE_PILEUPDIGITRACKERHITSMERGETOOL_H

--- a/FWCore/src/components/PileupDigiTrackHitMergeTool.h
+++ b/FWCore/src/components/PileupDigiTrackHitMergeTool.h
@@ -23,7 +23,6 @@ class MCParticleCollection;
  * While merging, this algorithm tries to keep the trackIDs unique by adding the pileup event number with an offset.
  * This should be transparent, but the trackIDs will be non-consecutive.
  *
- *
  */
 
 class PileupDigiTrackHitMergeTool : public GaudiTool, virtual public IEDMMergeTool {
@@ -85,6 +84,16 @@ private:
 
   /// offset with which the pileup event number is added to the trackID
   const unsigned int m_trackIDCollectionOffset = 2.5e6;
+
+  /// Mask to obtain system ID
+  const unsigned long long m_systemMask = 0xf;
+
+  /// Private function internally used to check if a hit is a tracker hit
+  bool isTrackerHit(unsigned long long cellId) const;
 };
+
+inline bool PileupDigiTrackHitMergeTool::isTrackerHit(unsigned long long cellId) const {
+  return ((cellId & m_systemMask) < 5);
+}
 
 #endif  // FWCORE_PILEUPDIGITRACKERHITSMERGETOOL_H

--- a/FWCore/src/components/PileupDigiTrackHitMergeTool.h
+++ b/FWCore/src/components/PileupDigiTrackHitMergeTool.h
@@ -1,0 +1,74 @@
+#ifndef FWCORE_PILEUPDIGITRACKERHITSMERGETOOL_H
+#define FWCORE_PILEUPDIGITRACKERHITSMERGETOOL_H
+
+// Gaudi
+#include "GaudiAlg/GaudiTool.h"
+
+// FCCSW
+#include "FWCore/DataHandle.h"
+#include "FWCore/IEDMMergeTool.h"
+
+namespace fcc {
+class PositionedTrackHit;
+class PositionedTrackHitCollection;
+class DigiTrackHitAssociation;
+class DigiTrackHitAssociationCollection;
+}
+
+/** @class PileupDigiTrackHitMergeTool
+ *
+ * Implemenation of the MergeTool for Digitization hits.
+ * While merging, this algorithm tries to keep the trackIDs unique by adding the pileup event number with an offset.
+ * This should be transparent, but the trackIDs will be non-consecutive.
+ *
+ *
+ */
+
+class PileupDigiTrackHitMergeTool : public GaudiTool, virtual public IEDMMergeTool {
+public:
+  explicit PileupDigiTrackHitMergeTool(const std::string& aType, const std::string& aName, const IInterface* aParent);
+  virtual ~PileupDigiTrackHitMergeTool() = default;
+
+  virtual StatusCode initialize() override final;
+
+  virtual StatusCode finalize() override final;
+
+  /// fill the member containers of collection pointers in this class with a collection from the event store
+  virtual StatusCode readPileupCollection(podio::EventStore& store) override final;
+
+  /// merge the collections in the member container and put them on  the event store
+  virtual StatusCode mergeCollections() override final;
+
+  /// fill the member container of collection pointer with a collection from the event store
+  virtual StatusCode readSignal() override final;
+
+private:
+  /// Name of the branch from which to read pileup collection
+  Gaudi::Property<std::string> m_pileupHitsBranchName{this, "pileupHitsBranch", "positionedHits",
+                                                      "Name of the branch from which to read pileup collection"};
+  /// Name of the branch from which to read pileup collection
+  Gaudi::Property<std::string> m_pileupPosHitsBranchName{this, "pileupDigiHitsBranch", "digiHits",
+                                                         "Name of the branch from which to read pileup collection"};
+
+  /// internal container to keep of collections to be merged
+  std::vector<const fcc::PositionedTrackHitCollection*> m_hitCollections;
+  /// internal container to keep of collections to be merged
+  std::vector<const fcc::DigiTrackHitAssociationCollection*> m_digiTrackHitsCollection;
+
+  /// Output of this tool: merged collection
+  DataHandle<fcc::PositionedTrackHitCollection> m_hitsMerged{"overlay/hits", Gaudi::DataHandle::Writer, this};
+  /// Output of this tool: merged collection
+  DataHandle<fcc::DigiTrackHitAssociationCollection> m_digiHitsMerged{"overlay/digiHits", Gaudi::DataHandle::Writer,
+                                                                      this};
+
+  /// input to this tool: signal collection
+  DataHandle<fcc::PositionedTrackHitCollection> m_hitsSignal{"overlay/signalHits", Gaudi::DataHandle::Reader, this};
+  /// input to this tool: signal collection
+  DataHandle<fcc::DigiTrackHitAssociationCollection> m_posHitsSignal{"overlay/signalDigiHits",
+                                                                     Gaudi::DataHandle::Reader, this};
+
+  /// offset with which the pileup event number is added to the trackID
+  const unsigned int m_trackIDCollectionOffset = 2 << 20;
+};
+
+#endif  // FWCORE_PILEUPDIGITRACKERHITSMERGETOOL_H


### PR DESCRIPTION
This pull request implements a pile up merge tool for `DigiTrackHitAssociation` with its corresponding `PositionedTrackHit`.
It is also possible to `MCParticle`, if the history is needed.
