### PR TITLE
Introduce Charginos and Neutralinos + their physics

### DIFF
--- a/Sim/SimG4Common/SimG4Common/CharginoMinus.h
+++ b/Sim/SimG4Common/SimG4Common/CharginoMinus.h
@@ -1,0 +1,41 @@
+#ifndef SIMG4COMMON_CHARGINOMINUS_H
+#define SIMG4COMMON_CHARGINOMINUS_H
+
+#include "G4ParticleDefinition.hh"
+#include "G4ios.hh"
+#include "globals.hh"
+
+/** @class sim::CharginoMinus SimG4Common/SimG4Common/CharginoMinus.h CharginoMinus.h
+*
+*  Chargino Minus particle definition for Geant4.
+*  name of the particle: 's_chi_minus_1'.
+*  pdg of the particle : -1000024
+*  charge              : negative
+*  Since the properties as e.g. mass, width, lifetime, of the Chargino are not known (it is a hypothetical particle)
+* they need to be set at construction.
+*
+*  @author Julia Hrdinka
+*
+*/
+
+namespace sim {
+class CharginoMinus : public G4ParticleDefinition {
+private:
+  /// instance
+  static CharginoMinus* s_theInstance;
+  /// default constructor
+  CharginoMinus() {}
+  /// destructor
+  ~CharginoMinus() {}
+
+public:
+  /// public definition method
+  static CharginoMinus* Definition(G4double mass = -1, G4double width = -1, G4bool stable = true,
+                                   G4double lifetime = -1);
+  /// the pdg ID of the particle
+  static int pdgID;
+  /// the name of the particle
+  static std::string name;
+};
+}
+#endif  // SIMG4COMMON_CHARGINOMINUS_H

--- a/Sim/SimG4Common/SimG4Common/CharginoPhysics.h
+++ b/Sim/SimG4Common/SimG4Common/CharginoPhysics.h
@@ -1,0 +1,75 @@
+#ifndef SIMG4COMMON_CHARGINOPHYSICS_H
+#define SIMG4COMMON_CHARGINOPHYSICS_H
+
+// Geant
+#include "G4VPhysicsConstructor.hh"
+
+/** @class CharginoPhysics SimG4Common/SimG4Common/CharginoPhysics.h CharginoPhysics.h
+ *
+ *  Physics constructor for simple chargino physics.
+ *  It defines the chargino plus/minus and the neutralino.
+ *  Ionisation and multiple scattering is defined for the charginos as well as their decay into a neutralino and a pion.
+ *
+ *  @author Julia Hrdinka
+ */
+
+namespace sim {
+class CharginoPhysics : public G4VPhysicsConstructor {
+public:
+  /// helper struct to configure charginos and neutralinos
+  struct ParticleConfiguration {
+    double mass = 101.0 * CLHEP::GeV;
+    double width = 0.0 * CLHEP::MeV;
+    bool stable = true;
+    double lifetime = -1;
+  };
+  /// default constructor.
+  CharginoPhysics();
+  /// Constructor.
+  CharginoPhysics(ParticleConfiguration charginoPlus, ParticleConfiguration charginoMinus,
+                  ParticleConfiguration neutralino);
+  /// Destructor.
+  virtual ~CharginoPhysics();
+  /// Add the process of parametrisation to every existing particle
+  ///(created by the G4ModularPhysicsList to which it is registered)
+  virtual void ConstructProcess() final;
+  /// Construction of particles. Nothing to be done by fast sim (parametrisation).
+  virtual void ConstructParticle() final;
+
+private:
+  /// chargino mass
+  double m_charginoPlusMass = 101.0 * CLHEP::GeV;
+  /// The width of the chargino
+  double m_charginoPlusWidth = 0.0 * CLHEP::MeV;
+  /// Flag indicating if the chargino is stable
+  bool m_charginoPlusStable = true;
+  /// The life time of the chargino
+  double m_charginoPlusLifetime = -1;
+  /// the chargino plus
+  G4ParticleDefinition* m_charginoPlus;
+
+  /// chargino mass
+  double m_charginoMinusMass = 101.0 * CLHEP::GeV;
+  /// The width of the chargino
+  double m_charginoMinusWidth = 0.0 * CLHEP::MeV;
+  /// Flag indicating if the chargino is stable
+  bool m_charginoMinusStable = true;
+  /// The life time of the chargino
+  double m_charginoMinusLifetime = -1;
+  /// the chargino minus
+  G4ParticleDefinition* m_charginoMinus;
+
+  /// neutralino mass
+  double m_neutralinoMass = 101.0 * CLHEP::GeV;
+  /// The width of the neutralino
+  double m_neutralinoWidth = 0.0 * CLHEP::MeV;
+  /// Flag indicating if the neutralino is stable
+  bool m_neutralinoStable = true;
+  /// The life time of the neutralino
+  double m_neutralinoLifetime = -1;
+  /// the neutralino
+  G4ParticleDefinition* m_neutralino;
+};
+}
+
+#endif  // SIMG4COMMON_CHARGINOPHYSICS_H

--- a/Sim/SimG4Common/SimG4Common/CharginoPlus.h
+++ b/Sim/SimG4Common/SimG4Common/CharginoPlus.h
@@ -1,0 +1,42 @@
+
+#ifndef SIMG4COMMON_CHARGINOPLUS_H
+#define SIMG4COMMON_CHARGINOPLUS_H
+
+#include "G4ParticleDefinition.hh"
+#include "G4ios.hh"
+#include "globals.hh"
+
+/** @class sim::CharginoPlus SimG4Common/SimG4Common/CharginoPlus.h CharginoPlus.h
+*
+*  Chargino Plus particle definition for Geant4.
+*  name of the particle: 's_chi_plus_1'.
+*  pdg of the particle : 1000024
+*  charge              : positive
+*  Since the properties as e.g. mass, width, lifetime, of the Chargino are not known (it is a hypothetical particle)
+* they need to be set at construction.
+*
+*  @author Julia Hrdinka
+*
+*/
+
+namespace sim {
+class CharginoPlus : public G4ParticleDefinition {
+private:
+  /// instance
+  static CharginoPlus* s_theInstance;
+  /// default constructor
+  CharginoPlus() {}
+  /// destructor
+  ~CharginoPlus() {}
+
+public:
+  /// public definition method
+  static CharginoPlus* Definition(G4double mass = -1, G4double width = -1, G4bool stable = true,
+                                  G4double lifetime = -1);
+  /// the pdg ID of the particle
+  static int pdgID;
+  /// the name of the particle
+  static std::string name;
+};
+}
+#endif  // SIMG4COMMON_CHARGINOPLUS_H

--- a/Sim/SimG4Common/SimG4Common/Neutralino.h
+++ b/Sim/SimG4Common/SimG4Common/Neutralino.h
@@ -1,0 +1,41 @@
+#ifndef SIMG4COMMON_NEUTRALINO_H
+#define SIMG4COMMON_NEUTRALINO_H
+
+#include "G4ParticleDefinition.hh"
+#include "G4ios.hh"
+#include "globals.hh"
+
+/** @class sim::Neutralino SimG4Common/SimG4Common/Neutralino.h Neutralino.h
+*
+*  Neutralino particle definition for Geant4.
+*  name of the particle: 's_chi_0_1'
+*  pdg of the particle : 1000022
+*  charge              : neutral
+*  Since the properties as e.g. mass, width, lifetime, of the Neutralino are not known (it is a hypothetical particle)
+* they need to be set at construction.
+*
+*  @author Julia Hrdinka
+*
+*/
+
+namespace sim {
+
+class Neutralino : public G4ParticleDefinition {
+private:
+  /// instance
+  static Neutralino* s_theInstance;
+  /// default constructor
+  Neutralino() {}
+  /// destructor
+  ~Neutralino() {}
+
+public:
+  static Neutralino* Definition(G4double mass = -1, G4double width = -1, G4bool stable = true, G4double lifetime = -1);
+
+  /// the pdg ID of the particle
+  static int pdgID;
+  /// the name of the particle
+  static std::string name;
+};
+}
+#endif  // SIMG4COMMON_NEUTRALINO_H

--- a/Sim/SimG4Common/src/CharginoMinus.cpp
+++ b/Sim/SimG4Common/src/CharginoMinus.cpp
@@ -1,0 +1,43 @@
+// local
+#include "SimG4Common/CharginoMinus.h"
+
+namespace sim {
+CharginoMinus* CharginoMinus::s_theInstance = NULL;
+int CharginoMinus::pdgID = -1000024;
+std::string CharginoMinus::name = "s_chi_minus_1";
+
+CharginoMinus* CharginoMinus::Definition(G4double mass, G4double width, G4bool stable, G4double lifetime) {
+  if (s_theInstance != 0 && (mass >= 0. || width >= 0. || lifetime >= 0.)) {
+    G4ExceptionDescription description;
+    description << "Trying to redefine the Chargino Minus properties after it has been constructed is not allowed";
+    G4Exception("CharginoMinus", "FailedRedefinition", FatalException, description);
+    abort();
+  }
+
+  if (s_theInstance != 0) {
+    return s_theInstance;
+  }
+
+  //    Arguments for constructor are as follows
+  //               name             mass          width         charge
+  //             2*spin           parity  C-conjugation
+  //          2*Isospin       2*Isospin3       G-parity
+  //               type    lepton number  baryon number   PDG encoding
+  //             stable         lifetime    decay table
+  //             shortlived      subType    anti_encoding
+
+  if (mass >= 0) {
+    G4ParticleDefinition* anInstance =
+        new G4ParticleDefinition(name, mass, width, -1. * CLHEP::eplus, 1, 0, 0, 0, 0, 0, "supersymmetric", 0, 0, pdgID,
+                                 stable, lifetime, NULL, false, "CharginoMinus");
+    s_theInstance = reinterpret_cast<CharginoMinus*>(anInstance);
+    std::cout << "Defining chargino minus with Mass: " << mass << " and pdgID: " << pdgID << std::endl;
+    return s_theInstance;
+  } else {
+    G4ExceptionDescription description;
+    description << "Trying to create a particle with default constructor is not allowed";
+    G4Exception("CharginoMinus", "DefaultConstructorCalled", FatalException, description);
+    abort();
+  }
+}
+}

--- a/Sim/SimG4Common/src/CharginoPhysics.cpp
+++ b/Sim/SimG4Common/src/CharginoPhysics.cpp
@@ -1,0 +1,86 @@
+#include "SimG4Common/CharginoPhysics.h"
+#include "SimG4Common/CharginoMinus.h"
+#include "SimG4Common/CharginoPlus.h"
+#include "SimG4Common/Neutralino.h"
+
+// Geant4
+#include "G4DecayTable.hh"
+#include "G4FastSimulationManagerProcess.hh"
+#include "G4PhaseSpaceDecayChannel.hh"
+#include "G4PhysicsConstructorFactory.hh"
+#include "G4ProcessManager.hh"
+#include "G4VDecayChannel.hh"
+#include "G4hIonisation.hh"
+#include "G4hMultipleScattering.hh"
+
+namespace sim {
+
+G4_DECLARE_PHYSCONSTR_FACTORY(CharginoPhysics);
+
+CharginoPhysics::CharginoPhysics() : G4VPhysicsConstructor("CharginoPhysics") {}
+
+CharginoPhysics::CharginoPhysics(ParticleConfiguration charginoPlus, ParticleConfiguration charginoMinus,
+                                 ParticleConfiguration neutralino)
+    : G4VPhysicsConstructor("CharginoPhysics"),
+      m_charginoPlusMass(charginoPlus.mass),
+      m_charginoPlusWidth(charginoPlus.width),
+      m_charginoPlusStable(charginoPlus.stable),
+      m_charginoPlusLifetime(charginoPlus.lifetime),
+      m_charginoMinusMass(charginoMinus.mass),
+      m_charginoMinusWidth(charginoMinus.width),
+      m_charginoMinusStable(charginoMinus.stable),
+      m_charginoMinusLifetime(charginoMinus.lifetime),
+      m_neutralinoMass(neutralino.mass),
+      m_neutralinoWidth(neutralino.width),
+      m_neutralinoStable(neutralino.stable),
+      m_neutralinoLifetime(neutralino.lifetime) {}
+
+CharginoPhysics::~CharginoPhysics() {}
+
+void CharginoPhysics::ConstructParticle() {
+  // construct the particles
+  std::cout << "ConstructParticle for CharginoPhysics" << std::endl;
+  m_charginoPlus = sim::CharginoPlus::Definition(m_charginoPlusMass, m_charginoPlusWidth, m_charginoPlusStable,
+                                                 m_charginoPlusLifetime);
+
+  m_charginoMinus = sim::CharginoMinus::Definition(m_charginoMinusMass, m_charginoMinusWidth, m_charginoMinusStable,
+                                                   m_charginoMinusLifetime);
+
+  m_neutralino =
+      sim::Neutralino::Definition(m_neutralinoMass, m_neutralinoWidth, m_neutralinoStable, m_neutralinoLifetime);
+}
+
+void CharginoPhysics::ConstructProcess() {
+  // define physics
+  std::cout << "ConstructProcess for CharginoPhysics" << std::endl;
+
+  G4ProcessManager* charginoPlus = m_charginoPlus->GetProcessManager();
+  G4ProcessManager* charginoMinus = m_charginoMinus->GetProcessManager();
+
+  charginoPlus->AddProcess(new G4hMultipleScattering, -1, 1, 1);
+  charginoMinus->AddProcess(new G4hMultipleScattering, -1, 1, 1);
+  charginoPlus->AddProcess(new G4hIonisation, -1, 2, 2);
+  charginoMinus->AddProcess(new G4hIonisation, -1, 2, 2);
+
+  // decay
+  G4DecayTable* charginoPlusTable = m_charginoPlus->GetDecayTable();
+  if (!charginoPlusTable) {
+    charginoPlusTable = new G4DecayTable();
+  }
+  G4VDecayChannel* charginoPlusChannel =
+      new G4PhaseSpaceDecayChannel(m_charginoPlus->GetParticleName(), 1, 2, m_neutralino->GetParticleName(), "pi+");
+  charginoPlusTable->Insert(charginoPlusChannel);
+  std::cout << "Adding decay to pion and neutralino to " << m_charginoPlus->GetParticleName() << std::endl;
+  m_charginoPlus->SetDecayTable(charginoPlusTable);
+  //
+  G4DecayTable* charginoMinusTable = m_charginoMinus->GetDecayTable();
+  if (!charginoMinusTable) {
+    charginoMinusTable = new G4DecayTable();
+  }
+  G4VDecayChannel* charginoMinusChannel =
+      new G4PhaseSpaceDecayChannel(m_charginoMinus->GetParticleName(), 1, 2, m_neutralino->GetParticleName(), "pi-");
+  charginoMinusTable->Insert(charginoMinusChannel);
+  std::cout << "Adding decay to pion and neutralino to " << m_charginoMinus->GetParticleName() << std::endl;
+  m_charginoMinus->SetDecayTable(charginoMinusTable);
+}
+}

--- a/Sim/SimG4Common/src/CharginoPlus.cpp
+++ b/Sim/SimG4Common/src/CharginoPlus.cpp
@@ -1,0 +1,43 @@
+// local
+#include "SimG4Common/CharginoPlus.h"
+
+namespace sim {
+CharginoPlus* CharginoPlus::s_theInstance = NULL;
+int CharginoPlus::pdgID = 1000024;
+std::string CharginoPlus::name = "s_chi_plus_1";
+
+CharginoPlus* CharginoPlus::Definition(G4double mass, G4double width, G4bool stable, G4double lifetime) {
+  if (s_theInstance != 0 && (mass >= 0. || width >= 0. || lifetime >= 0.)) {
+    G4ExceptionDescription description;
+    description << "Trying to redefine the Chargino Plus properties after it has been constructed is not allowed";
+    G4Exception("CharginoPlus", "FailedRedefinition", FatalException, description);
+    abort();
+  }
+
+  if (s_theInstance != 0) {
+    return s_theInstance;
+  }
+
+  //    Arguments for constructor are as follows
+  //               name             mass          width         charge
+  //             2*spin           parity  C-conjugation
+  //          2*Isospin       2*Isospin3       G-parity
+  //               type    lepton number  baryon number   PDG encoding
+  //             stable         lifetime    decay table
+  //             shortlived      subType    anti_encoding
+  if (mass >= 0) {
+    G4ParticleDefinition* anInstance =
+        new G4ParticleDefinition(name, mass, width, +1. * CLHEP::eplus, 1, 0, 0, 0, 0, 0, "supersymmetric", 0, 0, pdgID,
+                                 stable, lifetime, NULL, false, "CharginoPlus");
+
+    s_theInstance = reinterpret_cast<CharginoPlus*>(anInstance);
+    std::cout << "Defining chargino plus with Mass: " << mass << " and pdgID: " << pdgID << std::endl;
+    return s_theInstance;
+  } else {
+    G4ExceptionDescription description;
+    description << "Trying to create a particle with default constructor is not allowed";
+    G4Exception("CharginoPlus", "DefaultConstructorCalled", FatalException, description);
+    abort();
+  }
+}
+}

--- a/Sim/SimG4Common/src/Neutralino.cpp
+++ b/Sim/SimG4Common/src/Neutralino.cpp
@@ -1,0 +1,44 @@
+// local
+#include "SimG4Common/Neutralino.h"
+
+namespace sim {
+Neutralino* Neutralino::s_theInstance = NULL;
+int Neutralino::pdgID = 1000022;
+std::string Neutralino::name = "s_chi_0_1";
+
+Neutralino* Neutralino::Definition(G4double mass, G4double width, G4bool stable, G4double lifetime) {
+  if (s_theInstance != 0 && (mass >= 0. || width >= 0. || lifetime >= 0.)) {
+    G4ExceptionDescription description;
+    description << "Trying to redefine theNeutralino properties after it has been constructed is not allowed";
+    G4Exception("Neutralino", "FailedRedefinition", FatalException, description);
+    abort();
+  }
+
+  if (s_theInstance != 0) {
+    return s_theInstance;
+  }
+
+  //    Arguments for constructor are as follows
+  //               name             mass          width         charge
+  //             2*spin           parity  C-conjugation
+  //          2*Isospin       2*Isospin3       G-parity
+  //               type    lepton number  baryon number   PDG encoding
+  //             stable         lifetime    decay table
+  //             shortlived      subType    anti_encoding
+
+  if (mass >= 0) {
+    G4ParticleDefinition* anInstance =
+        new G4ParticleDefinition(name, mass, width, 0. * CLHEP::eplus, 1, 0, 0, 0, 0, 0, "supersymmetric", 0, 0, pdgID,
+                                 stable, lifetime, NULL, false, "Neutralino");
+
+    s_theInstance = reinterpret_cast<Neutralino*>(anInstance);
+    std::cout << "Defining neutralino plus with Mass: " << mass << " and pdgID: " << pdgID << std::endl;
+    return s_theInstance;
+  } else {
+    G4ExceptionDescription description;
+    description << "Trying to create a particle with default constructor is not allowed";
+    G4Exception("Neutralino", "DefaultConstructorCalled", FatalException, description);
+    abort();
+  }
+}
+}

--- a/Sim/SimG4Components/src/SimG4CharginoPhysicsTool.cpp
+++ b/Sim/SimG4Components/src/SimG4CharginoPhysicsTool.cpp
@@ -1,0 +1,93 @@
+// local
+#include "SimG4CharginoPhysicsTool.h"
+
+// FCCSW
+#include "SimG4Common/CharginoMinus.h"
+#include "SimG4Common/CharginoPhysics.h"
+#include "SimG4Common/CharginoPlus.h"
+#include "SimG4Common/Neutralino.h"
+#include "SimG4Common/Units.h"
+
+// Gaudi
+#include "GaudiKernel/PhysicalConstants.h"
+
+// CLHEP
+#include <CLHEP/Random/RandFlat.h>
+
+// Geant4
+#include "G4Event.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4ParticleTable.hh"
+#include "G4VModularPhysicsList.hh"
+
+// datamodel
+#include "datamodel/GenVertexCollection.h"
+#include "datamodel/MCParticleCollection.h"
+
+// Declaration of the Tool
+DECLARE_TOOL_FACTORY(SimG4CharginoPhysicsTool)
+
+SimG4CharginoPhysicsTool::SimG4CharginoPhysicsTool(const std::string& aType, const std::string& aName,
+                                                   const IInterface* aParent)
+    : AlgTool(aType, aName, aParent) {
+  declareInterface<ISimG4PhysicsList>(this);
+  declareProperty("fullphysics", m_physicsListTool, "Handle for the full physics list tool");
+}
+
+SimG4CharginoPhysicsTool::~SimG4CharginoPhysicsTool() {}
+
+StatusCode SimG4CharginoPhysicsTool::initialize() {
+  if (AlgTool::initialize().isFailure()) {
+    return StatusCode::FAILURE;
+  }
+  m_physicsListTool.retrieve();
+  return StatusCode::SUCCESS;
+}
+
+StatusCode SimG4CharginoPhysicsTool::finalize() { return AlgTool::finalize(); }
+
+G4VModularPhysicsList* SimG4CharginoPhysicsTool::physicsList() {
+  debug() << "Construct physics for Charginos and Neutralinos" << endmsg;
+
+  debug() << "     charginoPlus mass  : " << m_charginoPlusMass << ", lifetime: " << m_charginoPlusLifetime << endmsg;
+  debug() << "     charginoMinus mass : " << m_charginoMinusMass << ", lifetime: " << m_charginoMinusLifetime << endmsg;
+  debug() << "     neutralino mass    : " << m_neutralinoMass << ", lifetime: " << m_neutralinoMass << endmsg;
+  // Configure Physics
+  sim::CharginoPhysics::ParticleConfiguration charginoPlusConfig;
+  charginoPlusConfig.mass = m_charginoPlusMass;
+  charginoPlusConfig.lifetime = m_charginoPlusLifetime;
+  charginoPlusConfig.stable = true;
+  charginoPlusConfig.width = 0.;
+  // in case particle is not stable
+  if (m_charginoPlusLifetime > 0.) {
+    charginoPlusConfig.stable = false;
+    charginoPlusConfig.width = CLHEP::hbar_Planck / m_charginoPlusLifetime;
+  }
+
+  sim::CharginoPhysics::ParticleConfiguration charginoMinusConfig;
+  charginoMinusConfig.mass = m_charginoMinusMass;
+  charginoMinusConfig.lifetime = m_charginoMinusLifetime;
+  charginoMinusConfig.stable = true;
+  charginoMinusConfig.width = 0.;
+  if (m_charginoMinusLifetime > 0.) {
+    charginoMinusConfig.stable = false;
+    charginoMinusConfig.width = CLHEP::hbar_Planck / m_charginoMinusLifetime;
+  }
+
+  sim::CharginoPhysics::ParticleConfiguration neutralinoConfig;
+  neutralinoConfig.mass = m_neutralinoMass;
+  neutralinoConfig.lifetime = m_neutralinoLifetime;
+  neutralinoConfig.stable = true;
+  neutralinoConfig.width = 0.;
+  if (m_neutralinoLifetime > 0.) {
+    neutralinoConfig.stable = false;
+    neutralinoConfig.width = CLHEP::hbar_Planck / m_neutralinoLifetime;
+  }
+
+  // ownership passed to SimG4Svc which will register it in G4RunManager. To be deleted in ~G4RunManager()
+  G4VModularPhysicsList* physicsList = m_physicsListTool->physicsList();
+  // register chargino physics
+  physicsList->RegisterPhysics(new sim::CharginoPhysics(charginoPlusConfig, charginoMinusConfig, neutralinoConfig));
+  // hand back physics list
+  return physicsList;
+}

--- a/Sim/SimG4Components/src/SimG4CharginoPhysicsTool.h
+++ b/Sim/SimG4Components/src/SimG4CharginoPhysicsTool.h
@@ -1,0 +1,66 @@
+#ifndef SIMG4COMPONENTS_G4CHARGINOPHYSICSTOOL_H
+#define SIMG4COMPONENTS_G4CHARGINOPHYSICSTOOL_H
+
+// Gaudi
+#include "GaudiKernel/AlgTool.h"
+#include "GaudiKernel/ToolHandle.h"
+
+// FCCSW
+#include "FWCore/DataHandle.h"
+#include "SimG4Interface/ISimG4PhysicsList.h"
+
+// Geant4
+#include "G4SystemOfUnits.hh"
+#include "G4VPhysicsConstructor.hh"
+
+// Forward declarations
+
+/** @class SimG4CharginoPhysicsTool SimG4CharginoPhysicsTool.h "SimG4CharginoPhysicsTool.h"
+*
+*  Tool that configures the physics list for charginos and neutralinos. Since the parameters of these hypothetical
+particles are not known, they are made configurable.
+*
+*  @author Julia Hrdinka
+*
+*/
+
+class SimG4CharginoPhysicsTool : public AlgTool, virtual public ISimG4PhysicsList {
+public:
+  /// Standard constructor
+  SimG4CharginoPhysicsTool(const std::string& type, const std::string& name, const IInterface* parent);
+  /// initialize gaudi interface method
+  virtual StatusCode initialize() final;
+  /// finalize gaudi interface method
+  virtual StatusCode finalize();
+  /// Get the physics list.
+  ///  @return pointer to G4VModularPhysicsList (ownership is transferred to the caller)
+  virtual G4VModularPhysicsList* physicsList();
+  /// Destructor
+  virtual ~SimG4CharginoPhysicsTool();
+
+private:
+  /// Handle for the full physics list tool
+  ToolHandle<ISimG4PhysicsList> m_physicsListTool{"SimG4FtfpBert", this, true};
+  /// The mass of the chargino - parameter can be configured by hand in job options
+  Gaudi::Property<double> m_charginoPlusMass{this, "CharginoPlusMass", 101.0 * CLHEP::GeV, "CharginoMass width"};
+  /// The life time of the chargino - parameter can be configured by hand in job options
+  Gaudi::Property<double> m_charginoPlusLifetime{this, "CharginoPlusLifetime", -1, "CharginoPlus life time"};
+
+  /// The mass of the chargino - parameter can be configured by hand in job options
+  Gaudi::Property<double> m_charginoMinusMass{this, "CharginoMinusMass", 101.0 * CLHEP::GeV, "CharginoMass width"};
+  /// The life time of the chargino - parameter can be configured by hand in job options
+  Gaudi::Property<double> m_charginoMinusLifetime{this, "CharginoMinusLifetime", -1, "CharginoMinus life time"};
+
+  /// The mass of the neutralino - parameter can be configured by hand in job options
+  Gaudi::Property<double> m_neutralinoMass{this, "NeutralinoMass", 101.0 * CLHEP::GeV, "NeutralinoMass width"};
+  /// The life time of the neutralino - parameter can be configured by hand in job options
+  Gaudi::Property<double> m_neutralinoLifetime{this, "NeutralinoLifetime", -1, "Neutralino life time"};
+  /// the chargino plus
+  G4ParticleDefinition* m_charginoPlus;
+  /// the chargino minus
+  G4ParticleDefinition* m_charginoMinus;
+  /// the neutralino
+  G4ParticleDefinition* m_neutralino;
+};
+
+#endif  // SIMG4COMPONENTS_G4CHARGINOPHYSICSTOOL_H


### PR DESCRIPTION
Changes proposed in this pull-request:

- Chargino, Neutralino definitions with mass, width and lifetime not defined
- Geant4 Physicslist which defines the Charginos and Neutralinos and the decay of the Charginos into the Neutralion and a pion
- CharginoPhysicsTool which can be configured and hands over the relevant parameters of the charginos and neutralino to the physics list

