### PR TITLE
Fixing failing Calo reconstruction tests

### DIFF
--- a/Reconstruction/RecCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noNoise.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noNoise.py
@@ -9,13 +9,13 @@ hcalEndcapCellsName = "HCalEndcapCells"
 hcalFwdCellsName = "HCalFwdCells"
 # Readouts
 ecalBarrelReadoutName = "ECalBarrelPhiEta"
-ecalEndcapReadoutName = "EMECPhiEta"
+ecalEndcapReadoutName = "EMECPhiEtaReco"
 ecalFwdReadoutName = "EMFwdPhiEta"
 hcalBarrelReadoutName = "HCalBarrelReadout"
 hcalExtBarrelReadoutName = "HCalExtBarrelReadout"
 hcalBarrelReadoutPhiEtaName = "BarHCal_Readout_phieta"
 hcalExtBarrelReadoutPhiEtaName = "ExtBarHCal_Readout_phieta"
-hcalEndcapReadoutName = "HECPhiEta"
+hcalEndcapReadoutName = "HECPhiEtaReco"
 hcalFwdReadoutName = "HFwdPhiEta"
 # Number of events
 num_events = 3
@@ -70,6 +70,36 @@ rewriteExtHcal = RewriteBitfield("RewriteExtHcal",
                                  inhits = "HCalExtBarrelCells",
                                  outhits = "newHCalExtBarrelCells")
 
+##############################################################################################################
+#######                                       REWRITE ENDCAP BITFIELD                            #############
+##############################################################################################################
+
+from Configurables import RewriteBitfield
+rewriteECalEC = RewriteBitfield("RewriteECalEC",
+                                # old bitfield (readout)
+                                oldReadoutName = "EMECPhiEta",
+                                # specify which fields are going to be deleted
+                                removeIds = ["sublayer"],
+                                # clusters are needed, with deposit position and cellID in bits
+                                newReadoutName = ecalEndcapReadoutName,
+                                debugPrint = 10,
+                                OutputLevel = INFO)
+rewriteECalEC.inhits.Path = "ECalEndcapCells"
+rewriteECalEC.outhits.Path = "newECalEndcapCells"
+
+rewriteHCalEC = RewriteBitfield("RewriteHCalEC",
+                                # old bitfield (readout)
+                                oldReadoutName = "HECPhiEta",
+                                # specify which fields are going to be deleted
+                                removeIds = ["sublayer"],
+                                # new bitfield (readout), with new segmentation
+                                newReadoutName = hcalEndcapReadoutName,
+                                debugPrint = 10,
+                                OutputLevel = INFO)
+# clusters are needed, with deposit position and cellID in bits
+rewriteHCalEC.inhits.Path = "HCalEndcapCells"
+rewriteHCalEC.outhits.Path = "newHCalEndcapCells"
+
 #Create calo clusters
 from Configurables import CreateCaloClustersSlidingWindow, CaloTowerTool
 from GaudiKernel.PhysicalConstants import pi
@@ -85,11 +115,11 @@ towers = CaloTowerTool("towers",
                                hcalFwdReadoutName = hcalFwdReadoutName,
                                OutputLevel = DEBUG)
 towers.ecalBarrelCells.Path = ecalBarrelCellsName
-towers.ecalEndcapCells.Path = ecalEndcapCellsName
+towers.ecalEndcapCells.Path = "newECalEndcapCells"
 towers.ecalFwdCells.Path = ecalFwdCellsName
 towers.hcalBarrelCells.Path = "newHCalBarrelCells"
 towers.hcalExtBarrelCells.Path ="newHCalExtBarrelCells"
-towers.hcalEndcapCells.Path = hcalEndcapCellsName
+towers.hcalEndcapCells.Path = "newHCalEndcapCells"
 towers.hcalFwdCells.Path = hcalFwdCellsName
 
 # Cluster variables
@@ -131,6 +161,8 @@ ApplicationMgr(
     TopAlg = [podioinput,
               rewriteHcal,
               rewriteExtHcal,
+              rewriteECalEC,
+              rewriteHCalEC,
               createClusters,
               out
               ],

--- a/Reconstruction/RecCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noiseFromFile.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noiseFromFile.py
@@ -74,6 +74,37 @@ rewriteExtHcal = RewriteBitfield("RewriteExtHcal",
 rewriteExtHcal.inhits.Path = "HCalExtBarrelCells"
 rewriteExtHcal.outhits.Path = "newHCalExtBarrelCells"
 
+##############################################################################################################
+#######                                       RECALIBRATE ECAL                                   #############
+##############################################################################################################
+
+from Configurables import RewriteBitfield
+rewriteECalEC = RewriteBitfield("RewriteECalEC",
+                                # old bitfield (readout)
+                                oldReadoutName = "EMECPhiEta",
+                                # specify which fields are going to be deleted
+                                removeIds = ["sublayer"],
+                                # new bitfield (readout), with new segmentation
+                                newReadoutName = ecalEndcapReadoutName,
+                                debugPrint = 10,
+                                OutputLevel= INFO)
+# clusters are needed, with deposit position and cellID in bits
+rewriteECalEC.inhits.Path = "ECalEndcapCells"
+rewriteECalEC.outhits.Path = "newECalEndcapCells"
+
+rewriteHCalEC = RewriteBitfield("RewriteHCalEC",
+                                # old bitfield (readout)
+                                oldReadoutName = "HECPhiEta",
+                                # specify which fields are going to be deleted
+                                removeIds = ["sublayer"],
+                                # new bitfield (readout), with new segmentation
+                                newReadoutName = hcalEndcapReadoutName,
+                                debugPrint = 10,
+                                OutputLevel = INFO)
+# clusters are needed, with deposit position and cellID in bits
+rewriteHCalEC.inhits.Path = "HCalEndcapCells"
+rewriteHCalEC.outhits.Path = "newHCalEndcapCells"
+
 # add noise, create all existing cells in detector
 from Configurables import NoiseCaloCellsFromFileTool, TubeLayerPhiEtaCaloTool,CreateCaloCells
 noiseBarrel = NoiseCaloCellsFromFileTool("NoiseBarrel",
@@ -120,7 +151,7 @@ createEcalEndcapCells = CreateCaloCells("CreateECalEndcapCells",
                                                 doCellCalibration=False, # already calibrated
                                                 addCellNoise=True, filterCellNoise=False,
                                                 noiseTool = noiseEndcap,
-                                                hits=ecalEndcapCellsName,
+                                                hits="newECalEndcapCells",
                                                 cells=ecalEndcapCellsName+"Noise")
 
 #Create calo clusters
@@ -181,6 +212,7 @@ ApplicationMgr(
     TopAlg = [podioinput,
               rewriteHcal,
               rewriteExtHcal,
+              rewriteECalEC,
               createEcalBarrelCells,
               createEcalEndcapCells,
               createClusters,

--- a/Reconstruction/RecCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noiseFromFile.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noiseFromFile.py
@@ -15,7 +15,7 @@ hcalBarrelReadoutName = "HCalBarrelReadout"
 hcalExtBarrelReadoutName = "HCalExtBarrelReadout"
 hcalBarrelReadoutPhiEtaName = "BarHCal_Readout_phieta"
 hcalExtBarrelReadoutPhiEtaName = "ExtBarHCal_Readout_phieta"
-hcalEndcapReadoutName = "HECPhiEta"
+hcalEndcapReadoutName = "HECPhiEtaReco"
 hcalFwdReadoutName = "HFwdPhiEta"
 # Number of events
 num_events = 3
@@ -75,7 +75,7 @@ rewriteExtHcal.inhits.Path = "HCalExtBarrelCells"
 rewriteExtHcal.outhits.Path = "newHCalExtBarrelCells"
 
 ##############################################################################################################
-#######                                       RECALIBRATE ECAL                                   #############
+#######                                       REWRITE ENDCAP BITFIELD                            #############
 ##############################################################################################################
 
 from Configurables import RewriteBitfield
@@ -213,6 +213,7 @@ ApplicationMgr(
               rewriteHcal,
               rewriteExtHcal,
               rewriteECalEC,
+              rewriteHCalEC,
               createEcalBarrelCells,
               createEcalEndcapCells,
               createClusters,

--- a/Reconstruction/RecCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noiseFromFile_resegHCal.py
+++ b/Reconstruction/RecCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noiseFromFile_resegHCal.py
@@ -63,6 +63,37 @@ resegmentExtHcal = RedoSegmentation("ReSegmentationExtHcal",
                                 inhits = "HCalExtBarrelPositions",
                                 outhits = "newHCalExtBarrelCells")
 
+##############################################################################################################
+#######                                       REWRITE ENDCAP BITFIELD                            #############
+##############################################################################################################
+
+from Configurables import RewriteBitfield
+rewriteECalEC = RewriteBitfield("RewriteECalEC",
+                                # old bitfield (readout)
+                                oldReadoutName = "EMECPhiEta",
+                                # specify which fields are going to be deleted
+                                removeIds = ["sublayer"],
+                                # new bitfield (readout), with new segmentation
+                                newReadoutName = ecalEndcapReadoutName,
+                                debugPrint = 10,
+                                OutputLevel= INFO)
+# clusters are needed, with deposit position and cellID in bits
+rewriteECalEC.inhits.Path = "ECalEndcapCells"
+rewriteECalEC.outhits.Path = "newECalEndcapCells"
+
+rewriteHCalEC = RewriteBitfield("RewriteHCalEC",
+                                # old bitfield (readout)
+                                oldReadoutName = "HECPhiEta",
+                                # specify which fields are going to be deleted
+                                removeIds = ["sublayer"],
+                                # new bitfield (readout), with new segmentation
+                                newReadoutName = hcalEndcapReadoutName,
+                                debugPrint = 10,
+                                OutputLevel = INFO)
+# clusters are needed, with deposit position and cellID in bits
+rewriteHCalEC.inhits.Path = "HCalEndcapCells"
+rewriteHCalEC.outhits.Path = "newHCalEndcapCells"
+
 # add noise, create all existing cells in detector
 from Configurables import NoiseCaloCellsFromFileTool, TubeLayerPhiEtaCaloTool, LayerPhiEtaCaloTool, CreateCaloCells
 noiseBarrel = NoiseCaloCellsFromFileTool("NoiseBarrel",
@@ -99,7 +130,7 @@ barrelHcalGeometry = LayerPhiEtaCaloTool("HcalBarrelGeo",
                                          activeVolumesNumber = 10)
 createHcalBarrelCells = CreateCaloCells("CreateHCalBarrelCells",
                                         geometryTool = barrelHcalGeometry,
-                                        doCellCalibration=False, # already calibrated                                                                                                                                                       
+                                        doCellCalibration=False, # already calibrated
                                         addCellNoise=True, filterCellNoise=False,
                                         noiseTool = noiseHcal,
                                         hits = hcalBarrelCellsName,
@@ -127,7 +158,7 @@ createEcalEndcapCells = CreateCaloCells("CreateECalEndcapCells",
                                                 doCellCalibration=False, # already calibrated
                                                 addCellNoise=True, filterCellNoise=False,
                                                 noiseTool = noiseEndcap,
-                                                hits=ecalEndcapCellsName,
+                                                hits="new"+ecalEndcapCellsName,
                                                 cells=ecalEndcapCellsName+"Noise")
 
 #Create calo clusters
@@ -186,8 +217,8 @@ out.AuditExecute = True
 
 ApplicationMgr(
     TopAlg = [podioinput,
-              #positionsHcal,
-              #resegmentHcal,
+              rewriteECalEC,
+              rewriteHCalEC,
               positionsExtHcal,
               resegmentExtHcal,
               createEcalBarrelCells,


### PR DESCRIPTION
Changes proposed in this pull-request:
- includes the rewriting of the Endcap cells before using the new readout for merged layers. This fixes a segmentation fault.

To be done:
- Issue with cellIDs in the FCChh ECal Barrel calorimeter. Needs further investigation.