### PR TITLE
Add CXX configuration in line with Gaudi config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,18 +15,41 @@ endif(SAS)
 find_package(GaudiProject)
 #---------------------------------------------------------------
 
+# Set up C++ Standard
+# ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "")
+
+if(NOT CMAKE_CXX_STANDARD MATCHES "14|17")
+  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
+endif()
+
+# Prevent CMake falls back to the latest standard the compiler does support
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Disables the use of compiler-specific extensions, hence makes sure the code
+# works for a wider range of compilers
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+message(STATUS "Setting C++ standard: '${CMAKE_CXX_STANDARD}'.")
+
+if (${APPLE})
+    set(CPP_STANDARD_FLAGS "-std=c++${CMAKE_CXX_STANDARD}\ -stdlib=libc++")
+    set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CPP_STANDARD_FLAGS}")
+
 configure_file(cmake/fccrun.in ${CMAKE_BINARY_DIR}/fccrun)
 configure_file(cmake/this_fccsw.sh.in ${CMAKE_BINARY_DIR}/this_fccsw.sh)
 
 install(FILES ${CMAKE_BINARY_DIR}/fccrun
         DESTINATION .
-        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ 
+        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
                     GROUP_EXECUTE GROUP_READ
                     WORLD_EXECUTE WORLD_READ
         RENAME run)
 install(FILES ${CMAKE_BINARY_DIR}/this_fccsw.sh
         DESTINATION .
-        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ 
+        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
                     GROUP_EXECUTE GROUP_READ
                     WORLD_EXECUTE WORLD_READ)
 

--- a/cmake/GaudiBuildFlags.cmake
+++ b/cmake/GaudiBuildFlags.cmake
@@ -1,5 +1,5 @@
-# define a minimun default version
-set(GAUDI_CXX_STANDARD_DEFAULT "c++14")
+# align minimun default cxx version with the cxx standard defined for fccsw
+set(GAUDI_CXX_STANDARD_DEFAULT "c++${CMAKE_CXX_STANDARD}")
 # overriddend depending on the compiler
 
 # special for GaudiHive
@@ -231,7 +231,6 @@ if(GAUDI_CXX_STANDARD STREQUAL "ansi")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ansi")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ansi")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=${GAUDI_CXX_STANDARD}")
   if(NOT GAUDI_CXX_STANDARD STREQUAL "c++98")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
   else()


### PR DESCRIPTION
Allow users to define the cxx standard through the cmake configuration with: `-DCMAKE_CXX_STANDARD=<standard>` and propagate changes to Gaudi. 

This aligns the CMake configuration of FCCSW with the rest of cmake projects,