### PR TITLE
Add CMAKE_PREFIX_PATH as a hint in find modules

### DIFF
--- a/cmake/FindFCCEDM.cmake
+++ b/cmake/FindFCCEDM.cmake
@@ -1,4 +1,4 @@
-set(searchpath ${FCCEDM_DIR} ${PODIO_DIR}  )
+set(searchpath ${FCCEDM_DIR} ${PODIO_DIR} ${CMAKE_PREFIX_PATH} )
 
 # first find the FCC EDM
 find_library(FCCEDM_LIBRARY

--- a/cmake/FindPODIO.cmake
+++ b/cmake/FindPODIO.cmake
@@ -1,4 +1,4 @@
-set(searchpath $ENV{PODIO}  )
+set(searchpath $ENV{PODIO} ${CMAKE_PREFIX_PATH}  )
 
 find_library(PODIO_LIBRARY
               NAMES podio


### PR DESCRIPTION
Currently `FindFCCEDM` and `FindPODIO` rely on `FCCEDM_DIR` and `PODIO_DIR` variables to find `fcc-edm` and `podio` respectively, these variables might not be set though.

This PR adds the standard variable `CMAKE_PREFIX_PATH` as a hint to find the directories inside the `Find<package>` modules. 

Nonetheless this is a workaround, these `Find` modules may not be needed since in both cases CMake already generates the corresponding `fccedm-config.cmake` and `podio-config.cmake` files in the installation directories with the required information so, when properly configured, both `Find` modules will be redundant.