### PR TITLE
Fix `this_fccsw`->`setup.sh`, added printouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CPP_STANDARD_FLAGS}")
 
 configure_file(cmake/fccrun.in ${CMAKE_BINARY_DIR}/fccrun)
-configure_file(cmake/this_fccsw.sh.in ${CMAKE_BINARY_DIR}/this_fccsw.sh)
+configure_file(cmake/setup.sh.in ${CMAKE_BINARY_DIR}/setup.sh)
 
 install(FILES ${CMAKE_BINARY_DIR}/fccrun
         DESTINATION .
@@ -47,11 +47,12 @@ install(FILES ${CMAKE_BINARY_DIR}/fccrun
                     GROUP_EXECUTE GROUP_READ
                     WORLD_EXECUTE WORLD_READ
         RENAME run)
-install(FILES ${CMAKE_BINARY_DIR}/this_fccsw.sh
+
+install(FILES ${CMAKE_BINARY_DIR}/setup.sh
         DESTINATION .
-        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
-                    GROUP_EXECUTE GROUP_READ
-                    WORLD_EXECUTE WORLD_READ)
+        PERMISSIONS OWNER_WRITE OWNER_READ
+                    GROUP_READ
+                    WORLD_READ)
 
 gaudi_project(FCCSW  v0r10
               USE Gaudi v29r2 )

--- a/FWCore/src/components/PodioOutput.cpp
+++ b/FWCore/src/components/PodioOutput.cpp
@@ -128,5 +128,6 @@ StatusCode PodioOutput::finalize() {
   m_datatree->Write();
   m_file->Write();
   m_file->Close();
+  info() << "Data written to: " << m_filename << endmsg;
   return StatusCode::SUCCESS;
 }

--- a/cmake/setup.sh.in
+++ b/cmake/setup.sh.in
@@ -11,7 +11,4 @@ export PYTHONPATH=$PYTHONPATH:$FCCSWBASEDIR/lib:$FCCSWBASEDIR/python
 export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$FCCSWBASEDIR
 
 
-# make sure gaudi scripts and modules are available
-export PYTHONPATH=$PYTHONPATH:$FCCVIEW/lib:$FCCVIEW/python
-export PATH=$PATH:$FCCVIEW/scripts:$FCCVIEW/bin
 

--- a/cmake/setup.sh.in
+++ b/cmake/setup.sh.in
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 # get path to script
-export FCCSWBASEDIR="$( cd "$(dirname "$0")" ; pwd -P )"
-export FCC_DETECTORS=$FWCCSWBASEDIR
+export FCCSWBASEDIR=@CMAKE_INSTALL_PREFIX@
+export FCC_DETECTORS=$FCCSWBASEDIR
 export FCC_PYTHIACARDS=$FCCSWBASEDIR
 
 export PATH=$PATH:$FCCSWBASEDIR/scripts:$FCCSWBASEDIR/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$FCCSWBASEDIR/lib
 export PYTHONPATH=$PYTHONPATH:$FCCSWBASEDIR/lib:$FCCSWBASEDIR/python
 export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$FCCSWBASEDIR
+
+
+# make sure gaudi scripts and modules are available
+export PYTHONPATH=$PYTHONPATH:$FCCVIEW/lib:$FCCVIEW/python
+export PATH=$PATH:$FCCVIEW/scripts:$FCCVIEW/bin
+

--- a/init.sh
+++ b/init.sh
@@ -38,6 +38,7 @@ setuppath="/cvmfs/fcc.cern.ch/sw/views/releases/externals/$versiontag/$platform/
 
 weekday=`date +%a`
 if test -f $setuppath ; then
+   echo "Setting up FCC externals from $setuppath"
    source $setuppath
 else
    echo "Setup script not found: $setuppath! "


### PR DESCRIPTION
Implements the suggestion from https://github.com/HEP-FCC/FCCSW/pull/353 to rename `this_fccsw.sh` and uses absolute paths from cmake, to avoid the issue with `dirname`. Also adds two printouts that I find useful, one gives some feedback what `init.sh` is doing, the other one prints the output filename at the end of the job.
