### PR TITLE
Prevent grep from existing in case of nomatch

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,13 @@
-
 #!/bin/sh -u
+
+# Set up the environment to build and test FCCSW
+# This script relies on CVMFS and the FCC Externals
+#
+# Usage:
+#   source init.sh         # Uses default value for the FCC Externals 94.2.0
+#   source init.sh 94.1.0  # Sets a the 94.1.0 version of the FCC Externals
+
+
 # set FCCSWBASEDIR to the directory containing this script
 export FCCSWBASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -47,5 +55,3 @@ else
    echo "Versions available for this platform:"
    ls -1 /cvmfs/fcc.cern.ch/sw/views/releases/externals/*/$platform/setup.sh
 fi
-
-#source /cvmfs/fcc.cern.ch/sw/views/releases/externals/94.2.0/x86_64-slc6-gcc62-opt/setup.sh

--- a/init.sh
+++ b/init.sh
@@ -21,7 +21,7 @@ fi
 # Guess OS
 ostag="x86_64-slc6"
 if test -f "/etc/redhat-release"; then
-   six=`grep "release 7" /etc/redhat-release`
+   six=`grep "release 7" /etc/redhat-release || echo ""`
    if test ! "x$six" = "x" ; then
       ostag="x86_64-centos7"
    fi


### PR DESCRIPTION
The current `init.sh` script fails if the internal `grep` command does not find any match. This avoids this situation so builds in SLC6 executed with `bash -e` do not fail.
