### PR TITLE
Fix compilation error in Pythia Interface

### DIFF
--- a/Generation/src/components/PythiaInterface.cpp
+++ b/Generation/src/components/PythiaInterface.cpp
@@ -92,17 +92,17 @@ StatusCode PythiaInterface::initialize() {
       scheme = 0;
     }
 
-    m_setting = std::unique_ptr<Pythia8::amcnlo_unitarised_interface>(new Pythia8::amcnlo_unitarised_interface(scheme));
-    m_pythiaSignal->setUserHooksPtr(m_setting.get());
+    m_setting = std::make_shared<Pythia8::amcnlo_unitarised_interface>(scheme);
+    m_pythiaSignal->setUserHooksPtr(m_setting);
   }
 
   // For jet matching, initialise the respective user hooks code.
   if (m_doMePsMatching) {
-    m_matching = std::unique_ptr<Pythia8::JetMatchingMadgraph>(new Pythia8::JetMatchingMadgraph());
-    if (!m_matching) {
+    m_matching = std::make_shared<Pythia8::JetMatchingMadgraph>();
+    if (nullptr == m_matching) {
       return Error(" Failed to initialise jet matching structures.");
     }
-    m_pythiaSignal->setUserHooksPtr(m_matching.get());
+    m_pythiaSignal->setUserHooksPtr(m_matching);
   }
 
   // jet clustering needed for matching

--- a/Generation/src/components/PythiaInterface.h
+++ b/Generation/src/components/PythiaInterface.h
@@ -53,9 +53,9 @@ private:
   bool m_doMePsMerging{false};
 
   /// Pythia8 engine for ME/PS matching
-  std::unique_ptr<Pythia8::JetMatchingMadgraph> m_matching{nullptr};
+  std::shared_ptr<Pythia8::JetMatchingMadgraph> m_matching{nullptr};
   /// Pythia8 engine for NLO ME/PS merging
-  std::unique_ptr<Pythia8::amcnlo_unitarised_interface> m_setting{nullptr};
+  std::shared_ptr<Pythia8::amcnlo_unitarised_interface> m_setting{nullptr};
 
   /// flag for additional printouts
   Gaudi::Property<bool> m_printPythiaStatistics{this, "printPythiaStatistics", false,


### PR DESCRIPTION
The master branch has stopped compiling for me (externals `96b.0.0`) and the error message
```
/home/vavolkl/repo/FCCSW/Generation/src/components/PythiaInterface.cpp: In member function ‘virtual StatusCode PythiaInterface::initialize()’:
/home/vavolkl/repo/FCCSW/Generation/src/components/PythiaInterface.cpp:96:52: error: no matching function for call to ‘Pythia8::Pythia::setUserHooksPtr(std::unique_ptr<Pythia8::amcnlo_unitarised_interface>::pointer)’
     m_pythiaSignal->setUserHooksPtr(m_setting.get());

``` 
led me to make the fixes in this PR. Not sure if there was a change in Pythia versions, and why this didn't come up before ...