### PR TITLE
Optional Copy to EOS at End of Job

### DIFF
--- a/FWCore/src/components/PodioOutput.cpp
+++ b/FWCore/src/components/PodioOutput.cpp
@@ -128,6 +128,10 @@ StatusCode PodioOutput::finalize() {
   m_datatree->Write();
   m_file->Write();
   m_file->Close();
-  info() << "Data written to: " << m_filename << endmsg;
+  info() << "Data written to: " << m_filename.value();
+  if (!m_filenameRemote.value().empty()) {
+    TFile::Cp(m_filename.value().c_str(), m_filenameRemote.value().c_str(), false);
+    info() << " and copied to: " << m_filenameRemote.value() << endmsg; 
+  }
   return StatusCode::SUCCESS;
 }

--- a/FWCore/src/components/PodioOutput.h
+++ b/FWCore/src/components/PodioOutput.h
@@ -37,6 +37,8 @@ private:
   /// Commands which output is to be kept
   Gaudi::Property<std::vector<std::string>> m_outputCommands{
       this, "outputCommands", {"keep *"}, "A set of commands to declare which collections to keep or drop."};
+  Gaudi::Property<std::string> m_filenameRemote{
+      this, "filenameRemote", "", "An optional file path to copy the outputfile to."};
   /// Switch for keeping or dropping outputs
   KeepDropSwitch m_switch;
   /// Needed for collection ID table


### PR DESCRIPTION
@clementhelsens this is likely more robust than copying in bash and will help simplify the EventProducer!