### PR TITLE
Topo clusteringto edm4hep branch oct21

### DIFF
--- a/Reconstruction/RecCalorimeter/CMakeLists.txt
+++ b/Reconstruction/RecCalorimeter/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(ROOT COMPONENTS Physics Tree)
 find_package(FCCEDM)
 find_package(PODIO)
 find_package(HepMC)
-
+find_package(EDM4HEP)
 
 
 set(CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}  ${DD4hep_ROOT}/cmake )
@@ -20,7 +20,7 @@ include( DD4hep )
 gaudi_add_module(RecCalorimeterPlugins
                  src/components/*.cpp
                  INCLUDE_DIRS FastJet ROOT FCCFWCore HepMC FCCEDM PODIO DD4hep DetInterface DetSegmentation Geant4 DetCommon RecInterface RecCalorimeter
-                 LINK_LIBRARIES FWCore Fastjet ROOT GaudiAlgLib FCCEDM PODIO HepMC DD4hep DetSegmentation DetCommon)
+                 LINK_LIBRARIES FWCore Fastjet ROOT GaudiAlgLib FCCEDM PODIO HepMC DD4hep DetSegmentation DetCommon EDM4HEP::edm4hep)
 target_link_libraries(RecCalorimeterPlugins ${Geant4_LIBRARIES})
 
 

--- a/Reconstruction/RecCalorimeter/src/components/CaloTopoCluster.h
+++ b/Reconstruction/RecCalorimeter/src/components/CaloTopoCluster.h
@@ -16,9 +16,9 @@
 class IGeoSvc;
 
 // datamodel
-namespace fcc {
-class CaloHit;
-class CaloHitCollection;
+namespace edm4hep {
+class CalorimeterHit;
+class CalorimeterHitCollection;
 class CaloClusterCollection;
 }
 
@@ -94,9 +94,9 @@ public:
 
 private:
   // Cluster collection
-  DataHandle<fcc::CaloClusterCollection> m_clusterCollection{"calo/clusters", Gaudi::DataHandle::Writer, this};
+  DataHandle<ClusterCollection> m_clusterCollection{"calo/clusters", Gaudi::DataHandle::Writer, this};
   // Cluster cells in collection
-  DataHandle<fcc::CaloHitCollection> m_clusterCellsCollection{"calo/clusterCells", Gaudi::DataHandle::Writer, this};
+  DataHandle<CalorimeterHitCollection> m_clusterCellsCollection{"calo/clusterCells", Gaudi::DataHandle::Writer, this};
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;
   /// Handle for the input tool

--- a/Reconstruction/RecCalorimeter/src/components/CaloTopoCluster.h
+++ b/Reconstruction/RecCalorimeter/src/components/CaloTopoCluster.h
@@ -19,7 +19,7 @@ class IGeoSvc;
 namespace edm4hep {
 class CalorimeterHit;
 class CalorimeterHitCollection;
-class CaloClusterCollection;
+class ClusterCollection;
 }
 
 namespace DD4hep {
@@ -69,7 +69,7 @@ public:
                                     int aLastNumSigma,
                                     std::vector<std::pair<uint64_t, double>>& aSeeds,
                                     const std::map<uint64_t, double>& aCells,
-                                    std::map<uint, std::vector<std::pair<uint64_t, uint>>>& aPreClusterCollection);
+                                    std::map<uint, std::vector<std::pair<uint64_t, int>>>& aPreClusterCollection);
 
   /** Search for neighbours and add them to preClusterCollection
    * The 
@@ -85,7 +85,7 @@ public:
   std::vector<std::pair<uint64_t, uint>>
   searchForNeighbours(const uint64_t aCellId, uint& aClusterID, int aNumSigma, const std::map<uint64_t, double>& aCells,
                       std::map<uint64_t, uint>& aClusterOfCell,
-                      std::map<uint, std::vector<std::pair<uint64_t, uint>>>& aPreClusterCollection,
+                      std::map<uint, std::vector<std::pair<uint64_t, int>>>& aPreClusterCollection,
 		      bool aAllowClusterMerge);
 
   StatusCode execute();
@@ -94,9 +94,9 @@ public:
 
 private:
   // Cluster collection
-  DataHandle<ClusterCollection> m_clusterCollection{"calo/clusters", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::ClusterCollection> m_clusterCollection{"calo/clusters", Gaudi::DataHandle::Writer, this};
   // Cluster cells in collection
-  DataHandle<CalorimeterHitCollection> m_clusterCellsCollection{"calo/clusterCells", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{"calo/clusterCells", Gaudi::DataHandle::Writer, this};
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;
   /// Handle for the input tool

--- a/Reconstruction/RecCalorimeter/src/components/CaloTopoClusterInputTool.cpp
+++ b/Reconstruction/RecCalorimeter/src/components/CaloTopoClusterInputTool.cpp
@@ -4,8 +4,8 @@
 #include "DetInterface/IGeoSvc.h"
 
 // datamodel
-#include "datamodel/CalorimeterHit.h"
-#include "datamodel/CalorimeterHitCollection.h"
+#include "edm4hep/CalorimeterHit.h"
+#include "edm4hep/CalorimeterHitCollection.h"
 
 // DD4hep
 #include "DD4hep/Detector.h"
@@ -47,65 +47,65 @@ StatusCode CaloTopoClusterInputTool::cellIDMap(std::map<uint64_t, double>& aCell
 
   // 1. ECAL barrel
   // Get the input collection with calorimeter cells
-  const edm::CalorimeterHitCollection* ecalBarrelCells = m_ecalBarrelCells.get();
+  const edm4hep::CalorimeterHitCollection* ecalBarrelCells = m_ecalBarrelCells.get();
   debug() << "Input Ecal barrel cell collection size: " << ecalBarrelCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *ecalBarrelCells) {
-    aCells.emplace(iCell.cellID(), iCell.energy());
+    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += ecalBarrelCells->size();
   
   // 2. ECAL endcap calorimeter
-  const edm::CalorimeterHitCollection* ecalEndcapCells = m_ecalEndcapCells.get();
+  const edm4hep::CalorimeterHitCollection* ecalEndcapCells = m_ecalEndcapCells.get();
   debug() << "Input Ecal endcap cell collection size: " << ecalEndcapCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *ecalEndcapCells) {
-    aCells.emplace(iCell.cellID(), iCell.energy());
+    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += ecalEndcapCells->size();
     
   // 3. ECAL forward calorimeter
-  const edm::CalorimeterHitCollection* ecalFwdCells = m_ecalFwdCells.get();
+  const edm4hep::CalorimeterHitCollection* ecalFwdCells = m_ecalFwdCells.get();
   debug() << "Input Ecal forward cell collection size: " << ecalFwdCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *ecalFwdCells) {
-    aCells.emplace(iCell.cellID(), iCell.energy());
+    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += ecalFwdCells->size();
   
   // 4. HCAL barrel
-  const edm::CalorimeterHitCollection* hcalBarrelCells = m_hcalBarrelCells.get();
+  const edm4hep::CalorimeterHitCollection* hcalBarrelCells = m_hcalBarrelCells.get();
   debug() << "Input hadronic barrel cell collection size: " << hcalBarrelCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalBarrelCells) {
-    aCells.emplace(iCell.cellID(), iCell.energy());
+    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += hcalBarrelCells->size();
   
   // 5. HCAL extended barrel
-  const edm::CalorimeterHitCollection* hcalExtBarrelCells = m_hcalExtBarrelCells.get();
+  const edm4hep::CalorimeterHitCollection* hcalExtBarrelCells = m_hcalExtBarrelCells.get();
   debug() << "Input hadronic extended barrel cell collection size: " << hcalExtBarrelCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalExtBarrelCells) {
-    aCells.emplace(iCell.cellID(), iCell.energy());
+    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += hcalExtBarrelCells->size();
   
   // 6. HCAL endcap calorimeter                                                                                                              
-  const edm::CalorimeterHitCollection* hcalEndcapCells = m_hcalEndcapCells.get();
+  const edm4hep::CalorimeterHitCollection* hcalEndcapCells = m_hcalEndcapCells.get();
   debug() << "Input Hcal endcap cell collection size: " << hcalEndcapCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalEndcapCells) {
-    aCells.emplace(iCell.cellID(), iCell.energy());
+    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += hcalEndcapCells->size();
   
   // 7. HCAL forward calorimeter
-  const edm::CalorimeterHitCollection* hcalFwdCells = m_hcalFwdCells.get();
+  const edm4hep::CalorimeterHitCollection* hcalFwdCells = m_hcalFwdCells.get();
   debug() << "Input Hcal forward cell collection size: " << hcalFwdCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalFwdCells) {
-    aCells.emplace(iCell.cellID(), iCell.energy());
+    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += hcalFwdCells->size();
   

--- a/Reconstruction/RecCalorimeter/src/components/CaloTopoClusterInputTool.cpp
+++ b/Reconstruction/RecCalorimeter/src/components/CaloTopoClusterInputTool.cpp
@@ -4,8 +4,8 @@
 #include "DetInterface/IGeoSvc.h"
 
 // datamodel
-#include "datamodel/CaloHit.h"
-#include "datamodel/CaloHitCollection.h"
+#include "datamodel/CalorimeterHit.h"
+#include "datamodel/CalorimeterHitCollection.h"
 
 // DD4hep
 #include "DD4hep/Detector.h"
@@ -41,71 +41,71 @@ StatusCode CaloTopoClusterInputTool::initialize() {
 
 StatusCode CaloTopoClusterInputTool::finalize() { return GaudiTool::finalize(); }
 
-StatusCode CaloTopoClusterInputTool::cellIdMap(std::map<uint64_t, double>& aCells) {
+StatusCode CaloTopoClusterInputTool::cellIDMap(std::map<uint64_t, double>& aCells) {
   aCells.clear();
   uint totalNumberOfCells = 0;
 
   // 1. ECAL barrel
   // Get the input collection with calorimeter cells
-  const fcc::CaloHitCollection* ecalBarrelCells = m_ecalBarrelCells.get();
+  const edm::CalorimeterHitCollection* ecalBarrelCells = m_ecalBarrelCells.get();
   debug() << "Input Ecal barrel cell collection size: " << ecalBarrelCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *ecalBarrelCells) {
-    aCells.emplace(iCell.cellId(), iCell.energy());
+    aCells.emplace(iCell.cellID(), iCell.energy());
   }
   totalNumberOfCells += ecalBarrelCells->size();
   
   // 2. ECAL endcap calorimeter
-  const fcc::CaloHitCollection* ecalEndcapCells = m_ecalEndcapCells.get();
+  const edm::CalorimeterHitCollection* ecalEndcapCells = m_ecalEndcapCells.get();
   debug() << "Input Ecal endcap cell collection size: " << ecalEndcapCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *ecalEndcapCells) {
-    aCells.emplace(iCell.cellId(), iCell.energy());
+    aCells.emplace(iCell.cellID(), iCell.energy());
   }
   totalNumberOfCells += ecalEndcapCells->size();
     
   // 3. ECAL forward calorimeter
-  const fcc::CaloHitCollection* ecalFwdCells = m_ecalFwdCells.get();
+  const edm::CalorimeterHitCollection* ecalFwdCells = m_ecalFwdCells.get();
   debug() << "Input Ecal forward cell collection size: " << ecalFwdCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *ecalFwdCells) {
-    aCells.emplace(iCell.cellId(), iCell.energy());
+    aCells.emplace(iCell.cellID(), iCell.energy());
   }
   totalNumberOfCells += ecalFwdCells->size();
   
   // 4. HCAL barrel
-  const fcc::CaloHitCollection* hcalBarrelCells = m_hcalBarrelCells.get();
+  const edm::CalorimeterHitCollection* hcalBarrelCells = m_hcalBarrelCells.get();
   debug() << "Input hadronic barrel cell collection size: " << hcalBarrelCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalBarrelCells) {
-    aCells.emplace(iCell.cellId(), iCell.energy());
+    aCells.emplace(iCell.cellID(), iCell.energy());
   }
   totalNumberOfCells += hcalBarrelCells->size();
   
   // 5. HCAL extended barrel
-  const fcc::CaloHitCollection* hcalExtBarrelCells = m_hcalExtBarrelCells.get();
+  const edm::CalorimeterHitCollection* hcalExtBarrelCells = m_hcalExtBarrelCells.get();
   debug() << "Input hadronic extended barrel cell collection size: " << hcalExtBarrelCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalExtBarrelCells) {
-    aCells.emplace(iCell.cellId(), iCell.energy());
+    aCells.emplace(iCell.cellID(), iCell.energy());
   }
   totalNumberOfCells += hcalExtBarrelCells->size();
   
   // 6. HCAL endcap calorimeter                                                                                                              
-  const fcc::CaloHitCollection* hcalEndcapCells = m_hcalEndcapCells.get();
+  const edm::CalorimeterHitCollection* hcalEndcapCells = m_hcalEndcapCells.get();
   debug() << "Input Hcal endcap cell collection size: " << hcalEndcapCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalEndcapCells) {
-    aCells.emplace(iCell.cellId(), iCell.energy());
+    aCells.emplace(iCell.cellID(), iCell.energy());
   }
   totalNumberOfCells += hcalEndcapCells->size();
   
   // 7. HCAL forward calorimeter
-  const fcc::CaloHitCollection* hcalFwdCells = m_hcalFwdCells.get();
+  const edm::CalorimeterHitCollection* hcalFwdCells = m_hcalFwdCells.get();
   debug() << "Input Hcal forward cell collection size: " << hcalFwdCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalFwdCells) {
-    aCells.emplace(iCell.cellId(), iCell.energy());
+    aCells.emplace(iCell.cellID(), iCell.energy());
   }
   totalNumberOfCells += hcalFwdCells->size();
   

--- a/Reconstruction/RecCalorimeter/src/components/CaloTopoClusterInputTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/CaloTopoClusterInputTool.h
@@ -10,9 +10,9 @@
 class IGeoSvc;
 
 // datamodel
-namespace fcc {
-  class CaloHit;
-  class CaloHitCollection;
+namespace edm4hep {
+  class CalorimeterHit;
+  class CalorimeterHitCollection;
 }
 
 namespace DD4hep {
@@ -47,27 +47,27 @@ public:
    */
   virtual StatusCode finalize() final;
 
-  /** cellIdMap
+  /** cellIDMap
    * Fills the given map with all cellIDs pointing to the cells energy.
    *  @return status code
    */
-  virtual StatusCode cellIdMap(std::map<uint64_t, double>& aCells) final;
+  virtual StatusCode cellIDMap(std::map<uint64_t, double>& aCells) final;
 
 private:
   /// Handle for electromagnetic barrel cells (input collection)
-  DataHandle<fcc::CaloHitCollection> m_ecalBarrelCells{"ecalBarrelCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<CalorimeterHitCollection> m_ecalBarrelCells{"ecalBarrelCells", Gaudi::DataHandle::Reader, this};
   /// Handle for ecal endcap calorimeter cells (input collection)
-  DataHandle<fcc::CaloHitCollection> m_ecalEndcapCells{"ecalEndcapCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<CalorimeterHitCollection> m_ecalEndcapCells{"ecalEndcapCells", Gaudi::DataHandle::Reader, this};
   /// Handle for ecal forward calorimeter cells (input collection)
-  DataHandle<fcc::CaloHitCollection> m_ecalFwdCells{"ecalFwdCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<CalorimeterHitCollection> m_ecalFwdCells{"ecalFwdCells", Gaudi::DataHandle::Reader, this};
   /// Handle for hadronic barrel cells (input collection)
-  DataHandle<fcc::CaloHitCollection> m_hcalBarrelCells{"hcalBarrelCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<CalorimeterHitCollection> m_hcalBarrelCells{"hcalBarrelCells", Gaudi::DataHandle::Reader, this};
   /// Handle for hadronic extended barrel cells (input collection)
-  DataHandle<fcc::CaloHitCollection> m_hcalExtBarrelCells{"hcalExtBarrelCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<CalorimeterHitCollection> m_hcalExtBarrelCells{"hcalExtBarrelCells", Gaudi::DataHandle::Reader, this};
   /// Handle for hcal endcap calorimeter cells (input collection)
-  DataHandle<fcc::CaloHitCollection> m_hcalEndcapCells{"hcalEndcapCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<CalorimeterHitCollection> m_hcalEndcapCells{"hcalEndcapCells", Gaudi::DataHandle::Reader, this};
   /// Handle for hcal forward calorimeter cells (input collection)
-  DataHandle<fcc::CaloHitCollection> m_hcalFwdCells{"hcalFwdCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<CalorimeterHitCollection> m_hcalFwdCells{"hcalFwdCells", Gaudi::DataHandle::Reader, this};
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;
   /// Name of the electromagnetic barrel readout

--- a/Reconstruction/RecCalorimeter/src/components/CaloTopoClusterInputTool.h
+++ b/Reconstruction/RecCalorimeter/src/components/CaloTopoClusterInputTool.h
@@ -55,19 +55,19 @@ public:
 
 private:
   /// Handle for electromagnetic barrel cells (input collection)
-  DataHandle<CalorimeterHitCollection> m_ecalBarrelCells{"ecalBarrelCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::CalorimeterHitCollection> m_ecalBarrelCells{"ecalBarrelCells", Gaudi::DataHandle::Reader, this};
   /// Handle for ecal endcap calorimeter cells (input collection)
-  DataHandle<CalorimeterHitCollection> m_ecalEndcapCells{"ecalEndcapCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::CalorimeterHitCollection> m_ecalEndcapCells{"ecalEndcapCells", Gaudi::DataHandle::Reader, this};
   /// Handle for ecal forward calorimeter cells (input collection)
-  DataHandle<CalorimeterHitCollection> m_ecalFwdCells{"ecalFwdCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::CalorimeterHitCollection> m_ecalFwdCells{"ecalFwdCells", Gaudi::DataHandle::Reader, this};
   /// Handle for hadronic barrel cells (input collection)
-  DataHandle<CalorimeterHitCollection> m_hcalBarrelCells{"hcalBarrelCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::CalorimeterHitCollection> m_hcalBarrelCells{"hcalBarrelCells", Gaudi::DataHandle::Reader, this};
   /// Handle for hadronic extended barrel cells (input collection)
-  DataHandle<CalorimeterHitCollection> m_hcalExtBarrelCells{"hcalExtBarrelCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::CalorimeterHitCollection> m_hcalExtBarrelCells{"hcalExtBarrelCells", Gaudi::DataHandle::Reader, this};
   /// Handle for hcal endcap calorimeter cells (input collection)
-  DataHandle<CalorimeterHitCollection> m_hcalEndcapCells{"hcalEndcapCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::CalorimeterHitCollection> m_hcalEndcapCells{"hcalEndcapCells", Gaudi::DataHandle::Reader, this};
   /// Handle for hcal forward calorimeter cells (input collection)
-  DataHandle<CalorimeterHitCollection> m_hcalFwdCells{"hcalFwdCells", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::CalorimeterHitCollection> m_hcalFwdCells{"hcalFwdCells", Gaudi::DataHandle::Reader, this};
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;
   /// Name of the electromagnetic barrel readout

--- a/Reconstruction/RecInterface/CMakeLists.txt
+++ b/Reconstruction/RecInterface/CMakeLists.txt
@@ -5,6 +5,7 @@ gaudi_subdir(RecInterface v1r0)
 
 find_package(FCCEDM)
 find_package(PODIO)
+find_package(EDM4HEP)
 
 gaudi_install_headers(RecInterface)
 

--- a/Reconstruction/RecInterface/RecInterface/ITopoClusterInputTool.h
+++ b/Reconstruction/RecInterface/RecInterface/ITopoClusterInputTool.h
@@ -4,8 +4,8 @@
 // Gaudi
 #include "GaudiKernel/IAlgTool.h"
 
-namespace fcc {
-class CaloHit;
+namespace edm4hep {
+class CalorimeterHit;
 }
 /** @class ITopoClusterInputTool RecInterface/RecInterface/ITopoClusterInput.h ITopoClusterInputTool.h
  *
@@ -18,7 +18,7 @@ class ITopoClusterInputTool : virtual public IAlgTool {
 public:
   DeclareInterfaceID(ITopoClusterInputTool, 1, 0);
 
-  virtual StatusCode cellIdMap(std::map<uint64_t, double>& aCells) = 0;
+  virtual StatusCode cellIDMap(std::map<uint64_t, double>& aCells) = 0;
  };
 
 #endif /* RECINTERFACE_ITOPOCLUSTERINPUTTOOL_H */


### PR DESCRIPTION
Changes proposed in this pull-request:

- port the calorimeter reconstruction 'topoClustering' algorithm to EDM4hep. Could only be compiled in an older version of the edm4hep branch as the head seems to be broken. 

To be done:
- port also the 'CellPositions' algorithm family which also rely on fcc::edm. The topo clustering should nevertheless run as such because the 'CellPositions' only use fcc::edm internally, they are used in the topoClustering to retrieve a dd4hep::position type.
