### PR TITLE
Fix system id for caloCellPosition [temporary, should refactor this]

### DIFF
--- a/Reconstruction/RecFCCeeCalorimeter/CMakeLists.txt
+++ b/Reconstruction/RecFCCeeCalorimeter/CMakeLists.txt
@@ -5,6 +5,16 @@ gaudi_subdir(RecFCCeeCalorimeter v1r0)
 
 gaudi_depends_on_subdirs(GaudiAlg FWCore Detector/DetInterface Detector/DetSegmentation Detector/DetCommon Reconstruction/RecInterface Reconstruction/RecCalorimeter)
 
+find_package(FastJet)
+find_package(ROOT COMPONENTS Physics Tree)
+find_package(FCCEDM)
+find_package(PODIO)
+find_package(HepMC)
 
+gaudi_add_module(RecFCCeeCalorimeterPlugins
+                 src/components/*.cpp
+                 INCLUDE_DIRS FWCore FastJet ROOT FWCore HepMC FCCEDM PODIO DD4hep DetInterface DetSegmentation Geant4 DetCommon RecInterface RecCalorimeter RecFCCeeCalorimeter
+                 LINK_LIBRARIES FWCore Fastjet ROOT GaudiAlgLib FCCEDM PODIO HepMC DD4hep DetSegmentation DetCommon)
+target_link_libraries(RecFCCeeCalorimeterPlugins ${Geant4_LIBRARIES})
 
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/options DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/RecFCCeeCalorimeter)

--- a/Reconstruction/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.cpp
+++ b/Reconstruction/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.cpp
@@ -1,4 +1,4 @@
-#include "CreateCaloCellPositions.h"
+#include "CreateCaloCellPositionsFCCee.h"
 
 // FCCSW
 #include "DetCommon/DetUtils.h"
@@ -13,9 +13,9 @@
 #include "datamodel/PositionedTrackHitCollection.h"
 #include "datamodel/TrackHitCollection.h"
 
-DECLARE_COMPONENT(CreateCaloCellPositions)
+DECLARE_COMPONENT(CreateCaloCellPositionsFCCee)
 
-CreateCaloCellPositions::CreateCaloCellPositions(const std::string& name, ISvcLocator* svcLoc)
+CreateCaloCellPositionsFCCee::CreateCaloCellPositionsFCCee(const std::string& name, ISvcLocator* svcLoc)
     : GaudiAlgorithm(name, svcLoc) {
   declareProperty("hits", m_hits, "Hit collection (input)");
   declareProperty("positionsECalBarrelTool", m_cellPositionsECalBarrelTool,
@@ -31,13 +31,13 @@ CreateCaloCellPositions::CreateCaloCellPositions(const std::string& name, ISvcLo
   declareProperty("positionedHits", m_positionedHits, "Output cell positions collection");
 }
 
-StatusCode CreateCaloCellPositions::initialize() {
+StatusCode CreateCaloCellPositionsFCCee::initialize() {
   StatusCode sc = GaudiAlgorithm::initialize();
   if (sc.isFailure()) return sc;
   return StatusCode::SUCCESS;
 }
 
-StatusCode CreateCaloCellPositions::execute() {
+StatusCode CreateCaloCellPositionsFCCee::execute() {
   // Get the input hit collection
   const auto* hits = m_hits.get();
   debug() << "Input hit collection size: " << hits->size() << endmsg;
@@ -50,9 +50,9 @@ StatusCode CreateCaloCellPositions::execute() {
     auto systemId = m_decoder->get(cellId, "system");
     dd4hep::Position posCell;
 
-    if (systemId == 5)  // ECAL BARREL system id
+    if (systemId == 4)  // ECAL BARREL system id
       posCell = m_cellPositionsECalBarrelTool->xyzPosition(cellId);
-    else if (systemId == 8)  // HCAL BARREL system id
+    else if (systemId == 10)  // HCAL BARREL system id
       posCell = m_cellPositionsHCalBarrelTool->xyzPosition(cellId);
     else if (systemId == 9)  // HCAL EXT BARREL system id
       posCell = m_cellPositionsHCalExtBarrelTool->xyzPosition(cellId);
@@ -82,4 +82,4 @@ StatusCode CreateCaloCellPositions::execute() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode CreateCaloCellPositions::finalize() { return GaudiAlgorithm::finalize(); }
+StatusCode CreateCaloCellPositionsFCCee::finalize() { return GaudiAlgorithm::finalize(); }

--- a/Reconstruction/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
+++ b/Reconstruction/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
@@ -1,0 +1,69 @@
+#ifndef DETCOMPONENTS_CREATECELLPOSITIONSFCCEE_H
+#define DETCOMPONENTS_CREATECELLPOSITIONSFCCEE_H
+
+// FCCSW
+#include "FWCore/DataHandle.h"
+#include "RecInterface/ICellPositionsTool.h"
+
+// Gaudi
+#include "GaudiAlg/GaudiAlgorithm.h"
+#include "GaudiKernel/ToolHandle.h"
+
+#include "datamodel/CaloHit.h"
+#include "datamodel/CaloHitCollection.h"
+#include "datamodel/PositionedCaloHit.h"
+#include "datamodel/PositionedCaloHitCollection.h"
+
+class IGeoSvc;
+
+/** @class CreateCaloCellPositions Reconstruction/RecCalorimeter/src/components/CreateCaloCellPositions.h
+ * CreateCaloCellPositions.h
+ *
+ *  Retrieve positions of the cells from cell ID.
+ *  This algorithm saves the centre position of the volume. Defined for all Calo-Subsystems within tools.
+ *
+ *  @author Coralie Neubueser
+ *
+ */
+
+class CreateCaloCellPositionsFCCee : public GaudiAlgorithm {
+
+public:
+  CreateCaloCellPositionsFCCee(const std::string& name, ISvcLocator* svcLoc);
+  /**  Initialize.
+   *   @return status code
+   */
+  StatusCode initialize();
+  /**  Execute.
+   *   @return status code
+   */
+  StatusCode execute();
+  /**  Finalize.
+   *   @return status code
+   */
+  StatusCode finalize();
+
+private:
+  /// Handle for tool to get positions in ECal Barrel
+  ToolHandle<ICellPositionsTool> m_cellPositionsECalBarrelTool;
+  /// Handle for tool to get positions in HCal Barrel and Ext Barrel, no Segmentation
+  ToolHandle<ICellPositionsTool> m_cellPositionsHCalBarrelTool;
+  /// Handle for tool to get positions in HCal Barrel and Ext Barrel, no Segmentation
+  ToolHandle<ICellPositionsTool> m_cellPositionsHCalExtBarrelTool;
+  /// Handle for tool to get positions in Calo Discs
+  ToolHandle<ICellPositionsTool> m_cellPositionsEMECTool;
+  /// Handle for tool to get positions in Calo Discs
+  ToolHandle<ICellPositionsTool> m_cellPositionsHECTool;
+  /// Handle for tool to get positions in Calo Discs
+  ToolHandle<ICellPositionsTool> m_cellPositionsEMFwdTool;
+  /// Handle for tool to get positions in Calo Discs
+  ToolHandle<ICellPositionsTool> m_cellPositionsHFwdTool;
+  /// Decoder for system ID
+  dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder("system:4");
+  /// Input collection
+  DataHandle<fcc::CaloHitCollection> m_hits{"hits/hits", Gaudi::DataHandle::Reader, this};
+  /// Output collection
+  DataHandle<fcc::PositionedCaloHitCollection> m_positionedHits{"hits/positionedHits", Gaudi::DataHandle::Writer, this};
+};
+
+#endif /* DETCOMPONENTS_CREATECELLPOSITIONSFCCEE_H */

--- a/Reconstruction/RecFCChhCalorimeter/src/components/CreateCaloCellPositions.cpp
+++ b/Reconstruction/RecFCChhCalorimeter/src/components/CreateCaloCellPositions.cpp
@@ -50,9 +50,9 @@ StatusCode CreateCaloCellPositions::execute() {
     auto systemId = m_decoder->get(cellId, "system");
     dd4hep::Position posCell;
 
-    if (systemId == 5)  // ECAL BARREL system id
+    if (systemId == 4)  // ECAL BARREL system id
       posCell = m_cellPositionsECalBarrelTool->xyzPosition(cellId);
-    else if (systemId == 8)  // HCAL BARREL system id
+    else if (systemId == 10)  // HCAL BARREL system id
       posCell = m_cellPositionsHCalBarrelTool->xyzPosition(cellId);
     else if (systemId == 9)  // HCAL EXT BARREL system id
       posCell = m_cellPositionsHCalExtBarrelTool->xyzPosition(cellId);


### PR DESCRIPTION
Fix the system id in order to have meaningful positions for the ECAL barrel. This is a temporary fix, we should probably refactor this to avoid such a hard coding, possibly with another way to retrieve the system ID on the flight if it is possible. Or by having only one position tool [here](https://github.com/HEP-FCC/FCCSW/blob/master/Reconstruction/RecFCChhCalorimeter/src/components/CreateCaloCellPositions.h#L48) and by calling this algorithm once per sub-system in the config file.