### PR TITLE
FCCee LAr ECAL geometry update

### DIFF
--- a/Detector/DetCommon/DetCommon/DetUtils.h
+++ b/Detector/DetCommon/DetCommon/DetUtils.h
@@ -3,6 +3,7 @@
 
 // FCCSW
 #include "DetSegmentation/FCCSWGridPhiEta.h"
+#include "DetSegmentation/FCCSWGridPhiTheta.h"
 
 // DD4hep
 #include "DD4hep/DetFactoryHelper.h"

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel.xml
@@ -23,15 +23,15 @@
     <!-- Inclination angle of the lead plates -->
     <constant name="InclinationAngle" value="50*degree"/>
     <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
-    <constant name="LArGapThickness" value="1.806*mm"/>
+    <constant name="LArGapThickness" value="1.239749*2*mm"/>
 
     <!-- Air margin, thicknesses of cryostat and LAr bath -->
     <constant name="AirMarginThickness" value="0*mm"/>
     <constant name="CryoThicknessFront" value="50*mm"/>
     <constant name="CryoThicknessBack" value="100*mm"/>
     <constant name="CryoThicknessSide" value="100*mm"/>
-    <constant name="LArBathThicknessFront" value="20*mm"/>
-    <constant name="LArBathThicknessBack" value="20*mm"/>
+    <constant name="LArBathThicknessFront" value="10*mm"/>
+    <constant name="LArBathThicknessBack" value="40*mm"/>
 
     <!-- air margin around calorimeter -->
     <constant name="BarCryoECal_rmin" value="BarECal_rmin+AirMarginThickness"/>
@@ -44,11 +44,11 @@
     <!-- thickness of active volume between two absorber plates at EMBarrel_rmin, measuring perpendicular to the readout plate -->
     <constant name="LAr_thickness" value="LArGapThickness"/>
     <!-- passive layer consists of lead in the middle and steel on the outside, glued -->
-    <constant name="Pb_thickness" value="1.5*mm*2./2.16"/>
+    <constant name="Pb_thickness" value="1.4*mm"/>
     <!-- total amount of steel in one passive plate: it is divided for the outside layer on top and bottom -->
-    <constant name="Steel_thickness" value="0.4*mm*2./2.16"/>
+    <constant name="Steel_thickness" value="0.4*mm"/>
     <!-- total amount of glue in one passive plate: it is divided for the outside layer on top and bottom -->
-    <constant name="Glue_thickness" value="0.26*mm*2./2.16"/>
+    <constant name="Glue_thickness" value="0.2*mm"/>
     <!-- readout in between two absorber plates -->
     <constant name="readout_thickness" value="1.2*mm"/>
   </define>
@@ -59,21 +59,21 @@
 
   <readouts>
     <!-- readout for the simulation -->
-    <!-- offset in eta is eta max value including cryostat -->
-    <readout name="ECalBarrelEta">
-      <segmentation type="GridEta" grid_size_eta="0.01" offset_eta="-1.0"/>
-      <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,eta:9</id>
+    <!-- offset in theta is theta max value including cryostat -->
+    <readout name="ECalBarrelTheta">
+        <segmentation type="GridTheta" grid_size_theta="0.5625" offset_theta="-pi/4"/>
+      <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:9</id>
     </readout>
     <!-- readout for the reconstruction -->
     <!-- phi position is calculated based on the centre of volume (hence it cannot be done in the simulation from energy deposits position) -->
-    <readout name="ECalBarrelPhiEta">
-      <segmentation type="FCCSWGridPhiEta" grid_size_eta="0.01" phi_bins="704" offset_eta="-1.0" offset_phi="-pi+(pi/704.)"/>
-      <id>system:4,cryo:1,type:3,subtype:3,layer:8,eta:9,phi:10</id>
+    <readout name="ECalBarrelPhiTheta">
+        <segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.5625" phi_bins="768" offset_theta="-pi/4" offset_phi="-pi+(pi/768.)"/>
+      <id>system:4,cryo:1,type:3,subtype:3,layer:8,theta:9,phi:10</id>
     </readout>
   </readouts>
 
   <detectors>
-    <detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelEta">
+    <detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelTheta">
       <sensitive type="SimpleCalorimeterSD"/>
       <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">
@@ -107,9 +107,9 @@
         <readout thickness="readout_thickness" sensitive="false">
           <material name="PCB"/>
         </readout>
-        <layers>
-	       <layer thickness="2*cm" repeat="1"/>
-	       <layer thickness="6.15*cm" repeat="7"/>
+        <layers> <!-- pcb electrode segmentation, values considered are parallel to the electrodes-->
+	       <layer thickness="1.5*cm" repeat="1"/>
+	       <layer thickness="3.5*cm" repeat="11"/>
         </layers>
       </calorimeter>
     </detector>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel.xml
@@ -60,15 +60,17 @@
   <readouts>
     <!-- readout for the simulation -->
     <!-- offset in theta is theta max value including cryostat -->
-    <readout name="ECalBarrelTheta">
-        <segmentation type="GridTheta" grid_size_theta="0.5625" offset_theta="-pi/4"/>
-      <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,theta:9</id>
+    <readout name="ECalBarrelEta">
+        <!-- segmentation type="GridTheta" grid_size_theta="0.5625" offset_theta="-0.83"/ -->
+        <segmentation type="GridEta" grid_size_eta="0.01" offset_eta="-1.0"/>
+      <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,eta:9</id>
     </readout>
     <!-- readout for the reconstruction -->
     <!-- phi position is calculated based on the centre of volume (hence it cannot be done in the simulation from energy deposits position) -->
-    <readout name="ECalBarrelPhiTheta">
-        <segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.5625" phi_bins="768" offset_theta="-pi/4" offset_phi="-pi+(pi/768.)"/>
-      <id>system:4,cryo:1,type:3,subtype:3,layer:8,theta:9,phi:10</id>
+    <readout name="ECalBarrelPhiEta">
+        <!-- segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.5625" phi_bins="768" offset_theta="-0.83" offset_phi="-pi+(pi/768.)"/ -->
+        <segmentation type="FCCSWGridPhiEta" grid_size_eta="0.01" phi_bins="768" offset_eta="-1.0" offset_phi="-pi+(pi/768.)"/>
+      <id>system:4,cryo:1,type:3,subtype:3,layer:8,eta:9,phi:10</id>
     </readout>
   </readouts>
 

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel.xml
@@ -59,7 +59,7 @@
 
   <readouts>
     <!-- readout for the simulation -->
-    <!-- offset in theta is theta max value including cryostat -->
+    <!-- offset in eta is eta max value including cryostat -->
     <readout name="ECalBarrelEta">
         <!-- segmentation type="GridTheta" grid_size_theta="0.5625" offset_theta="-0.83"/ -->
         <segmentation type="GridEta" grid_size_eta="0.01" offset_eta="-1.0"/>
@@ -109,7 +109,7 @@
         <readout thickness="readout_thickness" sensitive="false">
           <material name="PCB"/>
         </readout>
-        <layers> <!-- pcb electrode segmentation, values considered are parallel to the electrodes-->
+        <layers> <!-- pcb electrode longitudinal segmentation in the radial direction -->
 	       <layer thickness="1.5*cm" repeat="1"/>
 	       <layer thickness="3.5*cm" repeat="11"/>
         </layers>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel.xml
@@ -75,7 +75,7 @@
   </readouts>
 
   <detectors>
-    <detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelTheta">
+    <detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelEta">
       <sensitive type="SimpleCalorimeterSD"/>
       <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_calibration.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_calibration.xml
@@ -1,39 +1,29 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<?xml version="1.0" ?><lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
-  <info name="FCCee_ECalBarrel_calibration"
-        title="Settings for Calibration of Inclined ECal Barrel Calorimeter"
-        author="M.Aleksa,J.Faltova,A.Zaborowska, V. Volkl"
-        url="no"
-        status="development"
-        version="1.0">
+  <info author="M.Aleksa,J.Faltova,A.Zaborowska, V. Volkl" name="FCCee_ECalBarrel" status="development" title="Settings for FCCee Inclined ECal Barrel Calorimeter" url="no" version="1.0">
     <comment>
-      Calibration hits setup for the inclined EM calorimeter.
+      Settings for the inclined EM calorimeter.
       The barrel is filled with liquid argon. Passive material includes lead in the middle and steal on the outside, glued together.
       Passive plates are inclined by a certain angle from the radial direction.
       In between of two passive plates there is a readout.
-      Space between the plane and readout is of trapezoidal shape and filled with liquid argon.
-      Definition of sizes, visualization settings, readout and longitudinal segmentation are specified.
-      This file is used in the calculation of the sampling fraction that corrects energy for the energy deposited in the absorber.
-      Calculation of the sampling fraction can be done as both passive and active material is sensitive.
+      Space between the plate and readout is of trapezoidal shape and filled with liquid argon.
+      Definition of sizes, visualization settings, readout and longitudinal segmentation are specified. 
     </comment>
   </info>
 
   <define>
-    <!-- Inclination angle of the plates -->
+    <!-- Inclination angle of the lead plates -->
     <constant name="InclinationAngle" value="50*degree"/>
     <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
-    <constant name="LArGapThickness" value="1.806*mm"/>
-   
+    <constant name="LArGapThickness" value="1.239749*2*mm"/>
+
     <!-- Air margin, thicknesses of cryostat and LAr bath -->
     <constant name="AirMarginThickness" value="0*mm"/>
     <constant name="CryoThicknessFront" value="50*mm"/>
     <constant name="CryoThicknessBack" value="100*mm"/>
     <constant name="CryoThicknessSide" value="100*mm"/>
-    <constant name="LArBathThicknessFront" value="20*mm"/>
-    <constant name="LArBathThicknessBack" value="20*mm"/>
+    <constant name="LArBathThicknessFront" value="10*mm"/>
+    <constant name="LArBathThicknessBack" value="40*mm"/>
 
     <!-- air margin around calorimeter -->
     <constant name="BarCryoECal_rmin" value="BarECal_rmin+AirMarginThickness"/>
@@ -43,72 +33,77 @@
     <constant name="EMBarrel_rmin" value="BarCryoECal_rmin+CryoThicknessFront+LArBathThicknessFront"/>
     <constant name="EMBarrel_rmax" value="BarCryoECal_rmax-CryoThicknessBack-LArBathThicknessBack"/>
     <constant name="EMBarrel_dz" value="BarECal_dz-CryoThicknessSide"/>
-    <!-- thickness of active volume between two absorber plates, measuring perpendicular to the readout plate -->
+    <!-- thickness of active volume between two absorber plates at EMBarrel_rmin, measuring perpendicular to the readout plate -->
     <constant name="LAr_thickness" value="LArGapThickness"/>
     <!-- passive layer consists of lead in the middle and steel on the outside, glued -->
-    <constant name="Pb_thickness" value="1.5*mm*2./2.16"/>
+    <constant name="Pb_thickness" value="1.4*mm"/>
     <!-- total amount of steel in one passive plate: it is divided for the outside layer on top and bottom -->
-    <constant name="Steel_thickness" value="0.4*mm*2./2.16"/>
+    <constant name="Steel_thickness" value="0.4*mm"/>
     <!-- total amount of glue in one passive plate: it is divided for the outside layer on top and bottom -->
-    <constant name="Glue_thickness" value="0.26*mm*2./2.16"/>
+    <constant name="Glue_thickness" value="0.2*mm"/>
     <!-- readout in between two absorber plates -->
     <constant name="readout_thickness" value="1.2*mm"/>
   </define>
 
   <display>
-    <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughers="false" visible="true" />
+    <vis alpha="1" b="0.6" g="0.2" name="ecal_envelope" r="0.1" showDaughers="false" visible="true"/>
   </display>
 
   <readouts>
     <!-- readout for the simulation -->
-    <!-- offset in eta is eta max value including cryostat -->
+    <!-- offset in theta is theta max value including cryostat -->
     <readout name="ECalBarrelEta">
-      <segmentation type="GridEta" grid_size_eta="0.01" offset_eta="-1.0"/>
+        <!-- segmentation type="GridTheta" grid_size_theta="0.5625" offset_theta="-0.83"/ -->
+        <segmentation grid_size_eta="0.01" offset_eta="-1.0" type="GridEta"/>
       <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,eta:9</id>
     </readout>
     <!-- readout for the reconstruction -->
     <!-- phi position is calculated based on the centre of volume (hence it cannot be done in the simulation from energy deposits position) -->
     <readout name="ECalBarrelPhiEta">
-      <segmentation type="FCCSWGridPhiEta" grid_size_eta="0.01" phi_bins="704" offset_eta="-1.0" offset_phi="-pi+(pi/704.)"/>
+        <!-- segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.5625" phi_bins="768" offset_theta="-0.83" offset_phi="-pi+(pi/768.)"/ -->
+        <segmentation grid_size_eta="0.01" offset_eta="-1.0" offset_phi="-pi+(pi/768.)" phi_bins="768" type="FCCSWGridPhiEta"/>
       <id>system:4,cryo:1,type:3,subtype:3,layer:8,eta:9,phi:10</id>
     </readout>
   </readouts>
 
   <detectors>
-    <detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelEta">
+    <detector id="BarECal_id" name="ECalBarrel" readout="ECalBarrelTheta" type="EmCaloBarrelInclined">
       <sensitive type="SimpleCalorimeterSD"/>
-      <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
+      <dimensions dz="BarCryoECal_dz" rmax="BarCryoECal_rmax" rmin="BarCryoECal_rmin" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">
-              <material name="Aluminum"/>
-	      <dimensions rmin1="BarCryoECal_rmin" rmin2="BarCryoECal_rmin+CryoThicknessFront" rmax1="BarCryoECal_rmax-CryoThicknessBack" rmax2="BarCryoECal_rmax" dz="BarCryoECal_dz"/>
+        <material name="Aluminum"/>
+	      <dimensions dz="BarCryoECal_dz" rmax1="BarCryoECal_rmax-CryoThicknessBack" rmax2="BarCryoECal_rmax" rmin1="BarCryoECal_rmin" rmin2="BarCryoECal_rmin+CryoThicknessFront"/>
 	      <front sensitive="false"/> <!-- inner wall of the cryostat -->
 	      <side sensitive="false"/> <!-- both sides of the cryostat -->
 	      <back sensitive="false"/> <!-- outer wall of the cryostat -->
       </cryostat>
       <calorimeter name="EM_barrel">
-	      <dimensions rmin="EMBarrel_rmin" rmax="EMBarrel_rmax" dz="EMBarrel_dz" offset="-InclinationAngle"/>
+	<!-- offset defines the numbering of the modules: module==0 for phi=0 direction -->
+	      <dimensions dz="EMBarrel_dz" offset="-InclinationAngle" rmax="EMBarrel_rmax" rmin="EMBarrel_rmin"/>
 	      <active thickness="LAr_thickness">
           <material name="LAr"/>
+	  <!-- overlap offset is a specific feature of the construction; do not change! -->
+	  <!-- one volume for a gap on both side of the readout) --> 
           <overlap offset="0.5"/>
         </active>
         <passive>
-          <rotation angle="InclinationAngle"/> <!-- inclination angle -->
-	       <inner thickness="Pb_thickness" sensitive="true">
+          <rotation angle="InclinationAngle"/>  <!-- inclination angle -->
+	       <inner sensitive="true" thickness="Pb_thickness">
             <material name="Lead"/>
           </inner>
-	       <glue thickness="Glue_thickness" sensitive="true">
+	       <glue sensitive="true" thickness="Glue_thickness">
             <material name="lArCaloGlue"/>
           </glue>
-	       <outer thickness="Steel_thickness" sensitive="true">
+	       <outer sensitive="true" thickness="Steel_thickness">
             <material name="lArCaloSteel"/>
           </outer>
         </passive>
-        <readout thickness="readout_thickness" sensitive="true">
+        <readout sensitive="true" thickness="readout_thickness">
           <material name="PCB"/>
         </readout>
-        <layers>
-	       <layer thickness="2*cm" repeat="1"/>
-	       <layer thickness="6.15*cm" repeat="7"/>
+        <layers> <!-- pcb electrode segmentation, values considered are parallel to the electrodes-->
+	       <layer repeat="1" thickness="1.5*cm"/>
+	       <layer repeat="11" thickness="3.5*cm"/>
         </layers>
       </calorimeter>
     </detector>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_calibration.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_calibration.xml
@@ -67,7 +67,7 @@
   </readouts>
 
   <detectors>
-    <detector id="BarECal_id" name="ECalBarrel" readout="ECalBarrelTheta" type="EmCaloBarrelInclined">
+    <detector id="BarECal_id" name="ECalBarrel" readout="ECalBarrelEta" type="EmCaloBarrelInclined">
       <sensitive type="SimpleCalorimeterSD"/>
       <dimensions dz="BarCryoECal_dz" rmax="BarCryoECal_rmax" rmin="BarCryoECal_rmin" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_calibration.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_calibration.xml
@@ -51,7 +51,7 @@
 
   <readouts>
     <!-- readout for the simulation -->
-    <!-- offset in theta is theta max value including cryostat -->
+    <!-- offset in eta is eta max value including cryostat -->
     <readout name="ECalBarrelEta">
         <!-- segmentation type="GridTheta" grid_size_theta="0.5625" offset_theta="-0.83"/ -->
         <segmentation grid_size_eta="0.01" offset_eta="-1.0" type="GridEta"/>
@@ -101,7 +101,7 @@
         <readout sensitive="true" thickness="readout_thickness">
           <material name="PCB"/>
         </readout>
-        <layers> <!-- pcb electrode segmentation, values considered are parallel to the electrodes-->
+        <layers> <!-- pcb electrode longitudinal segmentation in the radial direction -->
 	       <layer repeat="1" thickness="1.5*cm"/>
 	       <layer repeat="11" thickness="3.5*cm"/>
         </layers>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_upstream.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_upstream.xml
@@ -1,114 +1,109 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<?xml version="1.0" ?><lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
-  <info name="FCCee_ECalBarrel_upstream"
-        title="Settings for Upstream Correction for Inclined ECal Barrel Calorimeter"
-        author="M.Aleksa,J.Faltova,A.Zaborowska, V. Volkl"
-        url="no"
-        status="development"
-        version="1.0">
+  <info author="M.Aleksa,J.Faltova,A.Zaborowska, V. Volkl" name="FCCee_ECalBarrel" status="development" title="Settings for FCCee Inclined ECal Barrel Calorimeter" url="no" version="1.0">
     <comment>
-      Setup for the upstream correction calculation for the inclined EM calorimeter.
+      Settings for the inclined EM calorimeter.
       The barrel is filled with liquid argon. Passive material includes lead in the middle and steal on the outside, glued together.
       Passive plates are inclined by a certain angle from the radial direction.
       In between of two passive plates there is a readout.
-      Space between the plane and readout is of trapezoidal shape and filled with liquid argon.
-      Definition of sizes, visualization settings, readout and longitudinal segmentation are specified.
-      This file is used in the calculation of the energy deposited in the upstream material (cryostat in front of the detector).
-      Cryostat volume can be distinguished by ID: 'cryostat'==1 and 'type'==1 (cryo front) or 2 (cryo back) or 3 (cryo sides) or 4 (LAr bath front) or 5 (LAr bath back).
+      Space between the plate and readout is of trapezoidal shape and filled with liquid argon.
+      Definition of sizes, visualization settings, readout and longitudinal segmentation are specified. 
     </comment>
   </info>
 
   <define>
-     <!-- Inclination angle of the plates -->
-     <constant name="InclinationAngle" value="50*degree"/>
-     <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
-     <constant name="LArGapThickness" value="1.806*mm"/>
-   
-     <!-- Air margin, thicknesses of cryostat and LAr bath -->
-     <constant name="AirMarginThickness" value="0*mm"/>
-     <constant name="CryoThicknessFront" value="50*mm"/>
-     <constant name="CryoThicknessBack" value="100*mm"/>
-     <constant name="CryoThicknessSide" value="100*mm"/>
-     <constant name="LArBathThicknessFront" value="20*mm"/>
-     <constant name="LArBathThicknessBack" value="20*mm"/>
+    <!-- Inclination angle of the lead plates -->
+    <constant name="InclinationAngle" value="50*degree"/>
+    <!-- thickness of active volume between two absorber plates at barrel Rmin, measured perpendicular to the readout plate -->
+    <constant name="LArGapThickness" value="1.239749*2*mm"/>
 
-     <!-- air margin around calorimeter -->
-     <constant name="BarCryoECal_rmin" value="BarECal_rmin+AirMarginThickness"/>
-     <constant name="BarCryoECal_rmax" value="BarECal_rmax-AirMarginThickness"/>
-     <constant name="BarCryoECal_dz" value="BarECal_dz"/>
-     <!-- calorimeter active volume -->
-     <constant name="EMBarrel_rmin" value="BarCryoECal_rmin+CryoThicknessFront+LArBathThicknessFront"/>
-     <constant name="EMBarrel_rmax" value="BarCryoECal_rmax-CryoThicknessBack-LArBathThicknessBack"/>
-     <constant name="EMBarrel_dz" value="BarECal_dz-CryoThicknessSide"/>
-     <!-- thickness of active volume between two absorber plates, measuring perpendicular to the readout plate -->
-     <constant name="LAr_thickness" value="LArGapThickness"/>
-     <!-- passive layer consists of lead in the middle and steel on the outside, glued -->
-     <constant name="Pb_thickness" value="1.5*mm*2./2.16"/>
-     <!-- total amount of steel in one passive plate: it is divided for the outside layer on top and bottom -->
-     <constant name="Steel_thickness" value="0.4*mm*2./2.16"/>
-     <!-- total amount of glue in one passive plate: it is divided for the outside layer on top and bottom -->
-     <constant name="Glue_thickness" value="0.26*mm*2./2.16"/>
-     <!-- readout in between two absorber plates -->
-     <constant name="readout_thickness" value="1.2*mm"/>
+    <!-- Air margin, thicknesses of cryostat and LAr bath -->
+    <constant name="AirMarginThickness" value="0*mm"/>
+    <constant name="CryoThicknessFront" value="50*mm"/>
+    <constant name="CryoThicknessBack" value="100*mm"/>
+    <constant name="CryoThicknessSide" value="100*mm"/>
+    <constant name="LArBathThicknessFront" value="10*mm"/>
+    <constant name="LArBathThicknessBack" value="40*mm"/>
+
+    <!-- air margin around calorimeter -->
+    <constant name="BarCryoECal_rmin" value="BarECal_rmin+AirMarginThickness"/>
+    <constant name="BarCryoECal_rmax" value="BarECal_rmax-AirMarginThickness"/>
+    <constant name="BarCryoECal_dz" value="BarECal_dz"/>
+    <!-- calorimeter active volume -->
+    <constant name="EMBarrel_rmin" value="BarCryoECal_rmin+CryoThicknessFront+LArBathThicknessFront"/>
+    <constant name="EMBarrel_rmax" value="BarCryoECal_rmax-CryoThicknessBack-LArBathThicknessBack"/>
+    <constant name="EMBarrel_dz" value="BarECal_dz-CryoThicknessSide"/>
+    <!-- thickness of active volume between two absorber plates at EMBarrel_rmin, measuring perpendicular to the readout plate -->
+    <constant name="LAr_thickness" value="LArGapThickness"/>
+    <!-- passive layer consists of lead in the middle and steel on the outside, glued -->
+    <constant name="Pb_thickness" value="1.4*mm"/>
+    <!-- total amount of steel in one passive plate: it is divided for the outside layer on top and bottom -->
+    <constant name="Steel_thickness" value="0.4*mm"/>
+    <!-- total amount of glue in one passive plate: it is divided for the outside layer on top and bottom -->
+    <constant name="Glue_thickness" value="0.2*mm"/>
+    <!-- readout in between two absorber plates -->
+    <constant name="readout_thickness" value="1.2*mm"/>
   </define>
-  
+
   <display>
-    <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughers="false" visible="true" />
+    <vis alpha="1" b="0.6" g="0.2" name="ecal_envelope" r="0.1" showDaughers="false" visible="true"/>
   </display>
 
   <readouts>
     <!-- readout for the simulation -->
-    <!-- offset in eta is eta max value including cryostat -->
+    <!-- offset in theta is theta max value including cryostat -->
     <readout name="ECalBarrelEta">
-      <segmentation type="GridEta" grid_size_eta="0.01" offset_eta="-1.0"/>
+        <!-- segmentation type="GridTheta" grid_size_theta="0.5625" offset_theta="-0.83"/ -->
+        <segmentation grid_size_eta="0.01" offset_eta="-1.0" type="GridEta"/>
       <id>system:4,cryo:1,type:3,subtype:3,layer:8,module:11,eta:9</id>
     </readout>
     <!-- readout for the reconstruction -->
     <!-- phi position is calculated based on the centre of volume (hence it cannot be done in the simulation from energy deposits position) -->
     <readout name="ECalBarrelPhiEta">
-      <segmentation type="FCCSWGridPhiEta" grid_size_eta="0.01" phi_bins="704" offset_eta="-1.0" offset_phi="-pi+(pi/704.)"/>
+        <!-- segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.5625" phi_bins="768" offset_theta="-0.83" offset_phi="-pi+(pi/768.)"/ -->
+        <segmentation grid_size_eta="0.01" offset_eta="-1.0" offset_phi="-pi+(pi/768.)" phi_bins="768" type="FCCSWGridPhiEta"/>
       <id>system:4,cryo:1,type:3,subtype:3,layer:8,eta:9,phi:10</id>
     </readout>
   </readouts>
 
   <detectors>
-    <detector id="BarECal_id" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelEta">
+    <detector id="BarECal_id" name="ECalBarrel" readout="ECalBarrelTheta" type="EmCaloBarrelInclined">
       <sensitive type="SimpleCalorimeterSD"/>
-      <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
+      <dimensions dz="BarCryoECal_dz" rmax="BarCryoECal_rmax" rmin="BarCryoECal_rmin" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">
         <material name="Aluminum"/>
-	<dimensions rmin1="BarCryoECal_rmin" rmin2="BarCryoECal_rmin+CryoThicknessFront" rmax1="BarCryoECal_rmax-CryoThicknessBack" rmax2="BarCryoECal_rmax" dz="BarCryoECal_dz"/>
-	<front sensitive="true"/>  <!-- inner wall of the cryostat -->
-	<side sensitive="false"/> <!-- both sides of the cryostat -->
-	<back sensitive="false"/> <!-- outer wall of the cryostat -->
+	      <dimensions dz="BarCryoECal_dz" rmax1="BarCryoECal_rmax-CryoThicknessBack" rmax2="BarCryoECal_rmax" rmin1="BarCryoECal_rmin" rmin2="BarCryoECal_rmin+CryoThicknessFront"/>
+	      <front sensitive="true"/> <!-- inner wall of the cryostat -->
+	      <side sensitive="false"/> <!-- both sides of the cryostat -->
+	      <back sensitive="false"/> <!-- outer wall of the cryostat -->
       </cryostat>
       <calorimeter name="EM_barrel">
-	      <dimensions rmin="EMBarrel_rmin" rmax="EMBarrel_rmax" dz="EMBarrel_dz" offset="-InclinationAngle"/>
+	<!-- offset defines the numbering of the modules: module==0 for phi=0 direction -->
+	      <dimensions dz="EMBarrel_dz" offset="-InclinationAngle" rmax="EMBarrel_rmax" rmin="EMBarrel_rmin"/>
 	      <active thickness="LAr_thickness">
           <material name="LAr"/>
+	  <!-- overlap offset is a specific feature of the construction; do not change! -->
+	  <!-- one volume for a gap on both side of the readout) --> 
           <overlap offset="0.5"/>
         </active>
         <passive>
-          <rotation angle="InclinationAngle"/> <!-- inclination angle -->
-	       <inner thickness="Pb_thickness" sensitive="false">
+          <rotation angle="InclinationAngle"/>  <!-- inclination angle -->
+	       <inner sensitive="false" thickness="Pb_thickness">
             <material name="Lead"/>
           </inner>
-	       <glue thickness="Glue_thickness" sensitive="false">
+	       <glue sensitive="false" thickness="Glue_thickness">
             <material name="lArCaloGlue"/>
           </glue>
-	       <outer thickness="Steel_thickness" sensitive="false">
+	       <outer sensitive="false" thickness="Steel_thickness">
             <material name="lArCaloSteel"/>
           </outer>
         </passive>
-        <readout thickness="readout_thickness" sensitive="false">
+        <readout sensitive="false" thickness="readout_thickness">
           <material name="PCB"/>
         </readout>
-        <layers>
-	       <layer thickness="2*cm" repeat="1"/>
-	       <layer thickness="6.15*cm" repeat="7"/>
+        <layers> <!-- pcb electrode segmentation, values considered are parallel to the electrodes-->
+	       <layer repeat="1" thickness="1.5*cm"/>
+	       <layer repeat="11" thickness="3.5*cm"/>
         </layers>
       </calorimeter>
     </detector>

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_upstream.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_upstream.xml
@@ -67,7 +67,7 @@
   </readouts>
 
   <detectors>
-    <detector id="BarECal_id" name="ECalBarrel" readout="ECalBarrelTheta" type="EmCaloBarrelInclined">
+    <detector id="BarECal_id" name="ECalBarrel" readout="ECalBarrelEta" type="EmCaloBarrelInclined">
       <sensitive type="SimpleCalorimeterSD"/>
       <dimensions dz="BarCryoECal_dz" rmax="BarCryoECal_rmax" rmin="BarCryoECal_rmin" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">

--- a/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_upstream.xml
+++ b/Detector/DetFCCeeECalInclined/compact/FCCee_ECalBarrel_upstream.xml
@@ -51,7 +51,7 @@
 
   <readouts>
     <!-- readout for the simulation -->
-    <!-- offset in theta is theta max value including cryostat -->
+    <!-- offset in eta is eta max value including cryostat -->
     <readout name="ECalBarrelEta">
         <!-- segmentation type="GridTheta" grid_size_theta="0.5625" offset_theta="-0.83"/ -->
         <segmentation grid_size_eta="0.01" offset_eta="-1.0" type="GridEta"/>
@@ -101,7 +101,7 @@
         <readout sensitive="false" thickness="readout_thickness">
           <material name="PCB"/>
         </readout>
-        <layers> <!-- pcb electrode segmentation, values considered are parallel to the electrodes-->
+        <layers> <!-- pcb electrode longitudinal segmentation in the radial direction -->
 	       <layer repeat="1" thickness="1.5*cm"/>
 	       <layer repeat="11" thickness="3.5*cm"/>
         </layers>

--- a/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectDimensions.xml
+++ b/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectDimensions.xml
@@ -90,13 +90,13 @@
     <constant name="BarECal_id" value="DetID_ECAL_Barrel"/>
     <constant name="BarECal_rmin" value="2100*mm"/>
     <constant name="BarECal_rmax" value="2700*mm"/>
-    <constant name="BarECal_dz" value="2210*mm"/>
+    <constant name="BarECal_dz" value="2260*mm"/>
 
     <!-- HCAL Barrel -->
     <constant name="BarHCal_id" value="DetID_HCAL_Barrel"/>
     <constant name="BarHCal_rmin" value="2800*mm"/>
     <constant name="BarHCal_rmax" value="4100*mm"/>
-    <constant name="BarHCal_dz" value="2210*mm"/>
+    <constant name="BarHCal_dz" value="2260*mm"/>
 
     <constant name="HCalEndcap_inner_radius" value="340*mm"/>
     <constant name="HCalEndcap_outer_radius" value="3566*mm"/>

--- a/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectDimensions.xml
+++ b/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectDimensions.xml
@@ -88,7 +88,7 @@
 
     <!-- LAr ECAL Calo Barrel -->
     <constant name="BarECal_id" value="DetID_ECAL_Barrel"/>
-    <constant name="BarECal_rmin" value="2060*mm"/>
+    <constant name="BarECal_rmin" value="2100*mm"/>
     <constant name="BarECal_rmax" value="2700*mm"/>
     <constant name="BarECal_dz" value="2210*mm"/>
 

--- a/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
+++ b/Detector/DetFCChhECalInclined/src/ECalBarrelInclined_geo.cpp
@@ -177,7 +177,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
        << " thickness of outer part (cm) =  " << passiveOuterThickness
        << " thickness of total (cm) =  " << passiveThickness << " rotation angle = " << angle << endmsg;
   uint numPlanes =
-      M_PI / asin((passiveThickness + activeThickness + readoutThickness) / (2. * caloDim.rmin() * cos(angle)));
+      round(M_PI / asin((passiveThickness + activeThickness + readoutThickness) / (2. * caloDim.rmin() * cos(angle))));
   double dPhi = 2. * M_PI / numPlanes;
   lLog << MSG::INFO << "number of passive plates = " << numPlanes << " azim. angle difference =  " << dPhi << endmsg;
   lLog << MSG::INFO << " distance at inner radius (cm) = " << 2. * M_PI * caloDim.rmin() / numPlanes

--- a/Detector/DetSegmentation/DetSegmentation/FCCSWGridPhiTheta.h
+++ b/Detector/DetSegmentation/DetSegmentation/FCCSWGridPhiTheta.h
@@ -1,0 +1,87 @@
+#ifndef DETSEGMENTATION_GRIDPHITHETA_H
+#define DETSEGMENTATION_GRIDPHITHETA_H
+
+// FCCSW
+#include "DetSegmentation/GridTheta.h"
+
+/** FCCSWGridPhiTheta Detector/DetSegmentation/DetSegmentation/FCCSWGridPhiTheta.h FCCSWGridPhiTheta.h
+ *
+ *  Segmentation in theta and phi.
+ *  Based on GridTheta, addition of azimuthal angle coordinate.
+ *
+ *  @author    Anna Zaborowska
+ */
+
+namespace dd4hep {
+namespace DDSegmentation {
+class FCCSWGridPhiTheta : public GridTheta {
+public:
+  /// default constructor using an arbitrary type
+  FCCSWGridPhiTheta(const std::string& aCellEncoding);
+  /// Default constructor used by derived classes passing an existing decoder
+  FCCSWGridPhiTheta(const BitFieldCoder* decoder);
+
+  /// destructor
+  virtual ~FCCSWGridPhiTheta() = default;
+
+  /**  Determine the global position based on the cell ID.
+   *   @warning This segmentation has no knowledge of radius, so radius = 1 is taken into calculations.
+   *   @param[in] aCellId ID of a cell.
+   *   return Position (radius = 1).
+   */
+  virtual Vector3D position(const CellID& aCellID) const;
+  /**  Determine the cell ID based on the position.
+   *   @param[in] aLocalPosition (not used).
+   *   @param[in] aGlobalPosition position in the global coordinates.
+   *   @param[in] aVolumeId ID of a volume.
+   *   return Cell ID.
+   */
+  virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
+                        const VolumeID& aVolumeID) const;
+  /**  Determine the azimuthal angle based on the cell ID.
+   *   @param[in] aCellId ID of a cell.
+   *   return Phi.
+   */
+  double phi(const CellID& aCellID) const;
+  /**  Get the grid size in phi.
+   *   return Grid size in phi.
+   */
+  inline double gridSizePhi() const { return 2 * M_PI / static_cast<double>(m_phiBins); }
+  /**  Get the number of bins in azimuthal angle.
+   *   return Number of bins in phi.
+   */
+  inline int phiBins() const { return m_phiBins; }
+  /**  Get the coordinate offset in azimuthal angle.
+   *   return The offset in phi.
+   */
+  inline double offsetPhi() const { return m_offsetPhi; }
+  /**  Get the field name for azimuthal angle.
+   *   return The field name for phi.
+   */
+  inline const std::string& fieldNamePhi() const { return m_phiID; }
+  /**  Set the number of bins in azimuthal angle.
+   *   @param[in] aNumberBins Number of bins in phi.
+   */
+  inline void setPhiBins(int bins) { m_phiBins = bins; }
+  /**  Set the coordinate offset in azimuthal angle.
+   *   @param[in] aOffset Offset in phi.
+   */
+  inline void setOffsetPhi(double offset) { m_offsetPhi = offset; }
+  /**  Set the field name used for azimuthal angle.
+   *   @param[in] aFieldName Field name for phi.
+   */
+  inline void setFieldNamePhi(const std::string& fieldName) { m_phiID = fieldName; }
+
+protected:
+  /// determine the azimuthal angle phi based on the current cell ID
+  double phi() const;
+  /// the number of bins in phi
+  int m_phiBins;
+  /// the coordinate offset in phi
+  double m_offsetPhi;
+  /// the field name used for phi
+  std::string m_phiID;
+};
+}
+}
+#endif /* DETSEGMENTATION_GRIDPHITHETA_H */

--- a/Detector/DetSegmentation/DetSegmentation/FCCSWGridPhiThetaHandle.h
+++ b/Detector/DetSegmentation/DetSegmentation/FCCSWGridPhiThetaHandle.h
@@ -1,0 +1,119 @@
+#ifndef DD4HEP_DDCORE_GRIDPHITHETA_H
+#define DD4HEP_DDCORE_GRIDPHITHETA_H 1
+
+// FCCSW
+#include "DetSegmentation/FCCSWGridPhiTheta.h"
+
+// DD4hep
+#include "DD4hep/Segmentations.h"
+#include "DD4hep/detail/SegmentationsInterna.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+/// Namespace for base segmentations
+
+
+// Forward declarations
+class Segmentation;
+template <typename T>
+class SegmentationWrapper;
+
+/// We need some abbreviation to make the code more readable.
+typedef Handle<SegmentationWrapper<DDSegmentation::FCCSWGridPhiTheta>> FCCSWGridPhiThetaHandle;
+
+/// Implementation class for the grid phi-theta segmentation.
+/**
+ *  Concrete user handle to serve specific needs of client code
+ *  which requires access to the base functionality not served
+ *  by the super-class Segmentation.
+ *
+ *  Note:
+ *  We only check the validity of the underlying handle.
+ *  If for whatever reason the implementation object is not valid
+ *  This is not checked.
+ *  In principle this CANNOT happen unless some brain-dead has
+ *  fiddled with the handled object directly.....
+ *
+ *  Note:
+ *  The handle base corrsponding to this object in for
+ *  conveniance reasons instantiated in DD4hep/src/Segmentations.cpp.
+ *
+ *  \author  A. Zaborowska
+ *  \version 1.0
+ */
+class FCCSWGridPhiTheta : public FCCSWGridPhiThetaHandle {
+public:
+  /// Defintiion of the basic handled object
+  typedef FCCSWGridPhiThetaHandle::Object Object;
+
+public:
+  /// Default constructor
+  FCCSWGridPhiTheta() = default;
+  /// Copy constructor
+  FCCSWGridPhiTheta(const FCCSWGridPhiTheta& e) = default;
+  /// Copy Constructor from segmentation base object
+  FCCSWGridPhiTheta(const Segmentation& e) : Handle<Object>(e) {}
+  /// Copy constructor from handle
+  FCCSWGridPhiTheta(const Handle<Object>& e) : Handle<Object>(e) {}
+  /// Copy constructor from other polymorph/equivalent handle
+  template <typename Q>
+  FCCSWGridPhiTheta(const Handle<Q>& e) : Handle<Object>(e) {}
+  /// Assignment operator
+  FCCSWGridPhiTheta& operator=(const FCCSWGridPhiTheta& seg) = default;
+  /// Equality operator
+  bool operator==(const FCCSWGridPhiTheta& seg) const { return m_element == seg.m_element; }
+  /// determine the position based on the cell ID
+  inline Position position(const CellID& id) const { return Position(access()->implementation->position(id)); }
+
+  /// determine the cell ID based on the position
+  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {
+    return access()->implementation->cellID(local, global, volID);
+  }
+
+  /// access the grid size in theta
+  inline double gridSizeTheta() const { return access()->implementation->gridSizeTheta(); }
+
+  /// access the grid size in Phi
+  inline int phiBins() const { return access()->implementation->phiBins(); }
+
+  /// access the coordinate offset in theta
+  inline double offsetTheta() const { return access()->implementation->offsetTheta(); }
+
+  /// access the coordinate offset in Phi
+  inline double offsetPhi() const { return access()->implementation->offsetPhi(); }
+
+  /// set the coordinate offset in theta
+  inline void setOffsetTheta(double offset) const { access()->implementation->setOffsetTheta(offset); }
+
+  /// set the coordinate offset in Phi
+  inline void setOffsetPhi(double offset) const { access()->implementation->setOffsetPhi(offset); }
+
+  /// set the grid size in theta
+  inline void setGridSizeTheta(double cellSize) const { access()->implementation->setGridSizeTheta(cellSize); }
+
+  /// set the grid size in Phi
+  inline void setPhiBins(int cellSize) const { access()->implementation->setPhiBins(cellSize); }
+
+  /// access the field name used for theta
+  inline const std::string& fieldNameTheta() const { return access()->implementation->fieldNameTheta(); }
+
+  /// access the field name used for Phi
+  inline const std::string& fieldNamePhi() const { return access()->implementation->fieldNamePhi(); }
+
+  /** \brief Returns a std::vector<double> of the cellDimensions of the given cell ID
+      in natural order of dimensions (dPhi, dTheta)
+
+      Returns a std::vector of the cellDimensions of the given cell ID
+      \param cellID is ignored as all cells have the same dimension
+      \return std::vector<double> size 2:
+      -# size in phi
+      -# size in theta
+  */
+  inline std::vector<double> cellDimensions(const CellID& /*id*/) const {
+    return {access()->implementation->gridSizePhi(), access()->implementation->gridSizeTheta()};
+  }
+};
+
+} /* End namespace dd4hep                */
+#endif  // DD4HEP_DDCORE_GRIDPHITHETA_H

--- a/Detector/DetSegmentation/DetSegmentation/GridTheta.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridTheta.h
@@ -1,0 +1,103 @@
+#ifndef DETSEGMENTATION_GRIDTHETA_H
+#define DETSEGMENTATION_GRIDTHETA_H
+
+#include "DDSegmentation/Segmentation.h"
+
+/* #include "DDSegmentation/SegmentationUtil.h" */
+#include "TVector3.h"
+#include <cmath>
+
+/** GridTheta Detector/DetSegmentation/DetSegmentation/GridTheta.h GridTheta.h
+ *
+ *  Segmentation in theta.
+ *
+ *  @author    Anna Zaborowska
+ */
+
+namespace dd4hep {
+namespace DDSegmentation {
+class GridTheta : public Segmentation {
+public:
+  /// default constructor using an arbitrary type
+  GridTheta(const std::string& aCellEncoding);
+  /// Default constructor used by derived classes passing an existing decoder
+  GridTheta(const BitFieldCoder* decoder);
+  /// destructor
+  virtual ~GridTheta() = default;
+
+  /**  Determine the global position based on the cell ID.
+   *   @warning This segmentation has no knowledge of radius, so radius = 1 is taken into calculations.
+   *   @param[in] aCellId ID of a cell.
+   *   return Position (radius = 1).
+   */
+  virtual Vector3D position(const CellID& aCellID) const;
+  /**  Determine the cell ID based on the position.
+   *   @param[in] aLocalPosition (not used).
+   *   @param[in] aGlobalPosition position in the global coordinates.
+   *   @param[in] aVolumeId ID of a volume.
+   *   return Cell ID.
+   */
+  virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
+                        const VolumeID& aVolumeID) const;
+  /**  Determine the theta angle based on the cell ID.
+   *   @param[in] aCellId ID of a cell.
+   *   return Pseudorapidity.
+   */
+  double theta(const CellID& aCellID) const;
+  /**  Get the grid size in theta angle.
+   *   return Grid size in theta.
+   */
+  inline double gridSizeTheta() const { return m_gridSizeTheta; }
+  /**  Get the coordinate offset in theta angle.
+   *   return The offset in theta.
+   */
+  inline double offsetTheta() const { return m_offsetTheta; }
+  /**  Get the field name used for theta angle
+   *   return The field name for theta.
+   */
+  inline const std::string& fieldNameTheta() const { return m_thetaID; }
+  /**  Set the grid size in theta angle.
+   *   @param[in] aCellSize Cell size in theta.
+   */
+  inline void setGridSizeTheta(double aCellSize) { m_gridSizeTheta = aCellSize; }
+  /**  Set the coordinate offset in theta angle.
+   *   @param[in] aOffset Offset in theta.
+   */
+  inline void setOffsetTheta(double offset) { m_offsetTheta = offset; }
+  /**  Set the field name used for theta angle.
+   *   @param[in] aFieldName Field name for theta.
+   */
+  inline void setFieldNameTheta(const std::string& fieldName) { m_thetaID = fieldName; }
+  /// calculates the Cartesian position from spherical coordinates (r, phi, theta)
+  inline Vector3D positionFromRThetaPhi(double ar, double atheta, double aphi) const {
+    return Vector3D(ar * std::cos(aphi), ar * std::sin(aphi), ar * std::cos(atheta));
+  }
+  /// calculates the theta angle from Cartesian coordinates
+  inline double thetaFromXYZ(const Vector3D& aposition) const {
+    TVector3 vec(aposition.X, aposition.Y, aposition.Z);
+    return vec.Theta();
+  }
+  /// from SegmentationUtil
+  /// to be removed once SegmentationUtil can be included w/o linker error
+  /// calculates the azimuthal angle phi from Cartesian coordinates
+  inline double phiFromXYZ(const Vector3D& aposition) const { return std::atan2(aposition.Y, aposition.X); }
+  /// from SegmentationUtil
+  /// to be removed once SegmentationUtil can be included w/o linker error
+  /// calculates the radius in the xy-plane from Cartesian coordinates
+  inline double radiusFromXYZ(const Vector3D& aposition) const {
+    return std::sqrt(aposition.X * aposition.X + aposition.Y * aposition.Y);
+  }
+
+protected:
+  /// determine the theta angle based on the current cell ID
+  double theta() const;
+  /// the grid size in theta
+  double m_gridSizeTheta;
+  /// the coordinate offset in theta
+  double m_offsetTheta;
+  /// the field name used for theta
+  std::string m_thetaID;
+};
+}
+}
+#endif /* DETSEGMENTATION_GRIDTHETA_H */

--- a/Detector/DetSegmentation/DetSegmentation/GridThetaHandle.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridThetaHandle.h
@@ -1,0 +1,103 @@
+#ifndef DD4HEP_DDCORE_GRIDTHETA_H
+#define DD4HEP_DDCORE_GRIDTHETA_H 1
+
+// FCCSW
+#include "DetSegmentation/GridTheta.h"
+
+// DD4hep
+#include "DD4hep/Segmentations.h"
+#include "DD4hep/detail/SegmentationsInterna.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+/// Namespace for base segmentations
+
+
+// Forward declarations
+class Segmentation;
+template <typename T>
+class SegmentationWrapper;
+
+/// We need some abbreviation to make the code more readable.
+typedef Handle<SegmentationWrapper<DDSegmentation::GridTheta>> GridThetaHandle;
+
+/// Implementation class for the grid phi-theta segmentation.
+/**
+ *  Concrete user handle to serve specific needs of client code
+ *  which requires access to the base functionality not served
+ *  by the super-class Segmentation.
+ *
+ *  Note:
+ *  We only check the validity of the underlying handle.
+ *  If for whatever reason the implementation object is not valid
+ *  This is not checked.
+ *  In principle this CANNOT happen unless some brain-dead has
+ *  fiddled with the handled object directly.....
+ *
+ *  Note:
+ *  The handle base corrsponding to this object in for
+ *  conveniance reasons instantiated in DD4hep/src/Segmentations.cpp.
+ *
+ *  \author  A. Zaborowska
+ *  \version 1.0
+ */
+class GridTheta : public GridThetaHandle {
+public:
+  /// Defintiion of the basic handled object
+  typedef GridThetaHandle::Object Object;
+
+public:
+  /// Default constructor
+  GridTheta() = default;
+  /// Copy constructor
+  GridTheta(const GridTheta& e) = default;
+  /// Copy Constructor from segmentation base object
+  GridTheta(const Segmentation& e) : Handle<Object>(e) {}
+  /// Copy constructor from handle
+  GridTheta(const Handle<Object>& e) : Handle<Object>(e) {}
+  /// Copy constructor from other polymorph/equivalent handle
+  template <typename Q>
+  GridTheta(const Handle<Q>& e) : Handle<Object>(e) {}
+  /// Assignment operator
+  GridTheta& operator=(const GridTheta& seg) = default;
+  /// Equality operator
+  bool operator==(const GridTheta& seg) const { return m_element == seg.m_element; }
+  /// determine the position based on the cell ID
+  inline Position position(const CellID& id) const { return Position(access()->implementation->position(id)); }
+
+  /// determine the cell ID based on the position
+  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {
+    return access()->implementation->cellID(local, global, volID);
+  }
+
+  /// access the grid size in theta
+  inline double gridSizeTheta() const { return access()->implementation->gridSizeTheta(); }
+
+  /// access the coordinate offset in theta
+  inline double offsetTheta() const { return access()->implementation->offsetTheta(); }
+
+  /// set the coordinate offset in theta
+  inline void setOffsetTheta(double offset) const { access()->implementation->setOffsetTheta(offset); }
+
+  /// set the grid size in theta
+  inline void setGridSizeTheta(double cellSize) const { access()->implementation->setGridSizeTheta(cellSize); }
+
+  /// access the field name used for theta
+  inline const std::string& fieldNameTheta() const { return access()->implementation->fieldNameTheta(); }
+
+  /** \brief Returns a std::vector<double> of the cellDimensions of the given cell ID
+      in natural order of dimensions (dTheta)
+
+      Returns a std::vector of the cellDimensions of the given cell ID
+      \param cellID is ignored as all cells have the same dimension
+      \return std::vector<double> size 1:
+      -# size in theta
+  */
+  inline std::vector<double> cellDimensions(const CellID& /*id*/) const {
+    return {access()->implementation->gridSizeTheta()};
+  }
+};
+
+} /* End namespace dd4hep                */
+#endif  // DD4HEP_DDCORE_GRIDTHETA_H

--- a/Detector/DetSegmentation/src/FCCSWGridPhiTheta.cpp
+++ b/Detector/DetSegmentation/src/FCCSWGridPhiTheta.cpp
@@ -1,0 +1,57 @@
+#include "DetSegmentation/FCCSWGridPhiTheta.h"
+
+namespace dd4hep {
+namespace DDSegmentation {
+
+/// default constructor using an encoding string
+FCCSWGridPhiTheta::FCCSWGridPhiTheta(const std::string& cellEncoding) : GridTheta(cellEncoding) {
+  // define type and description
+  _type = "FCCSWGridPhiTheta";
+  _description = "Phi-theta segmentation in the global coordinates";
+
+  // register all necessary parameters (additional to those registered in GridTheta)
+  registerParameter("phi_bins", "Number of bins phi", m_phiBins, 1);
+  registerParameter("offset_phi", "Angular offset in phi", m_offsetPhi, 0., SegmentationParameter::AngleUnit, true);
+  registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
+}
+
+FCCSWGridPhiTheta::FCCSWGridPhiTheta(const BitFieldCoder* decoder) : GridTheta(decoder) {
+  // define type and description
+  _type = "FCCSWGridPhiTheta";
+  _description = "Phi-theta segmentation in the global coordinates";
+
+  // register all necessary parameters (additional to those registered in GridTheta)
+  registerParameter("phi_bins", "Number of bins phi", m_phiBins, 1);
+  registerParameter("offset_phi", "Angular offset in phi", m_offsetPhi, 0., SegmentationParameter::AngleUnit, true);
+  registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
+}
+
+/// determine the local based on the cell ID
+Vector3D FCCSWGridPhiTheta::position(const CellID& cID) const {
+  return positionFromRThetaPhi(1.0, theta(cID), phi(cID));
+}
+
+/// determine the cell ID based on the position
+CellID FCCSWGridPhiTheta::cellID(const Vector3D& /* localPosition */, const Vector3D& globalPosition,
+                          const VolumeID& vID) const {
+  CellID cID = vID;
+  double lTheta = thetaFromXYZ(globalPosition);
+  double lPhi = phiFromXYZ(globalPosition);
+  _decoder->set(cID, m_thetaID, positionToBin(lTheta, m_gridSizeTheta, m_offsetTheta));
+  _decoder->set(cID, m_phiID, positionToBin(lPhi, 2 * M_PI / (double)m_phiBins, m_offsetPhi));
+  return cID;
+}
+
+/// determine the azimuthal angle phi based on the current cell ID
+//double FCCSWGridPhiTheta::phi() const {
+//  CellID phiValue = (*_decoder)[m_phiID].value();
+//  return binToPosition(phiValue, 2. * M_PI / (double)m_phiBins, m_offsetPhi);
+//}
+
+/// determine the azimuthal angle phi based on the cell ID
+double FCCSWGridPhiTheta::phi(const CellID& cID) const {
+  CellID phiValue = _decoder->get(cID, m_phiID);
+  return binToPosition(phiValue, 2. * M_PI / (double)m_phiBins, m_offsetPhi);
+}
+}
+}

--- a/Detector/DetSegmentation/src/FCCSWGridPhiThetaHandle.cpp
+++ b/Detector/DetSegmentation/src/FCCSWGridPhiThetaHandle.cpp
@@ -1,0 +1,4 @@
+#include "DetSegmentation/FCCSWGridPhiThetaHandle.h"
+#include "DD4hep/detail/Handle.inl"
+
+DD4HEP_INSTANTIATE_HANDLE_UNNAMED(dd4hep::DDSegmentation::FCCSWGridPhiTheta);

--- a/Detector/DetSegmentation/src/GridTheta.cpp
+++ b/Detector/DetSegmentation/src/GridTheta.cpp
@@ -1,0 +1,55 @@
+#include "DetSegmentation/GridTheta.h"
+
+namespace dd4hep {
+namespace DDSegmentation {
+
+/// default constructor using an encoding string
+GridTheta::GridTheta(const std::string& cellEncoding) : Segmentation(cellEncoding) {
+  // define type and description
+  _type = "GridTheta";
+  _description = "Theta segmentation in the global coordinates";
+
+  // register all necessary parameters
+  registerParameter("grid_size_theta", "Cell size in Theta", m_gridSizeTheta, 1., SegmentationParameter::LengthUnit);
+  registerParameter("offset_theta", "Angular offset in theta", m_offsetTheta, 0., SegmentationParameter::AngleUnit, true);
+  registerIdentifier("identifier_theta", "Cell ID identifier for theta", m_thetaID, "theta");
+}
+
+GridTheta::GridTheta(const BitFieldCoder* decoder) : Segmentation(decoder) {
+  // define type and description
+  _type = "GridTheta";
+  _description = "Etheta segmentation in the global coordinates";
+
+  // register all necessary parameters
+  registerParameter("grid_size_theta", "Cell size in Theta", m_gridSizeTheta, 1., SegmentationParameter::LengthUnit);
+  registerParameter("offset_theta", "Angular offset in theta", m_offsetTheta, 0., SegmentationParameter::AngleUnit, true);
+  registerIdentifier("identifier_theta", "Cell ID identifier for theta", m_thetaID, "theta");
+}
+
+/// determine the local based on the cell ID
+Vector3D GridTheta::position(const CellID& cID) const {
+  return positionFromRThetaPhi(1.0, theta(cID), 0.);
+}
+
+/// determine the cell ID based on the position
+CellID GridTheta::cellID(const Vector3D& /* localPosition */, const Vector3D& globalPosition, const VolumeID& vID) const {
+  CellID cID = vID;
+  double lTheta = thetaFromXYZ(globalPosition);
+  _decoder->set(cID, m_thetaID, positionToBin(lTheta, m_gridSizeTheta, m_offsetTheta));
+  return cID;
+}
+
+/// determine the pseudorapidity based on the current cell ID
+//double GridTheta::theta() const {
+//  CellID thetaValue = (*_decoder)[m_thetaID].value();
+//  return binToPosition(thetaValue, m_gridSizeTheta, m_offsetTheta);
+//}
+
+/// determine the polar angle theta based on the cell ID
+double GridTheta::theta(const CellID& cID) const {
+  CellID thetaValue = _decoder->get(cID, m_thetaID);
+  return binToPosition(thetaValue, m_gridSizeTheta, m_offsetTheta);
+}
+REGISTER_SEGMENTATION(GridTheta)
+}
+}

--- a/Detector/DetSegmentation/src/GridThetaHandle.cpp
+++ b/Detector/DetSegmentation/src/GridThetaHandle.cpp
@@ -1,0 +1,4 @@
+#include "DetSegmentation/GridThetaHandle.h"
+#include "DD4hep/detail/Handle.inl"
+
+DD4HEP_INSTANTIATE_HANDLE_UNNAMED(dd4hep::DDSegmentation::GridTheta);

--- a/Detector/DetSegmentation/src/plugins/SegmentationFactories.cpp
+++ b/Detector/DetSegmentation/src/plugins/SegmentationFactories.cpp
@@ -14,6 +14,12 @@ DECLARE_SEGMENTATION(GridEta, create_segmentation<dd4hep::DDSegmentation::GridEt
 #include "DetSegmentation/FCCSWGridPhiEta.h"
 DECLARE_SEGMENTATION(FCCSWGridPhiEta, create_segmentation<dd4hep::DDSegmentation::FCCSWGridPhiEta>)
 
+#include "DetSegmentation/GridTheta.h"
+DECLARE_SEGMENTATION(GridTheta, create_segmentation<dd4hep::DDSegmentation::GridTheta>)
+
+#include "DetSegmentation/FCCSWGridPhiTheta.h"
+DECLARE_SEGMENTATION(FCCSWGridPhiTheta, create_segmentation<dd4hep::DDSegmentation::FCCSWGridPhiTheta>)
+
 #include "DetSegmentation/GridRPhiEta.h"
 DECLARE_SEGMENTATION(GridRPhiEta, create_segmentation<dd4hep::DDSegmentation::GridRPhiEta>)
 

--- a/Reconstruction/RecFCCeeCalorimeter/options/runCaloSim.py
+++ b/Reconstruction/RecFCCeeCalorimeter/options/runCaloSim.py
@@ -106,7 +106,7 @@ geantsim = SimG4Alg("SimG4Alg",
 from Configurables import CalibrateInLayersTool
 calibEcalBarrel = CalibrateInLayersTool("CalibrateECalBarrel",
                                    # sampling fraction obtained using SamplingFractionInLayers from DetStudies package
-                                   samplingFraction = [0.306224547517] * 1 + [0.111664096145] * 1 + [0.135828948734] * 1 + [0.151690753987] * 1 + [0.163564788854] * 1 + [0.172627758875] * 1 + [0.180023941499] * 1 + [0.186642705553] * 1 + [0.192229484697] * 1 + [0.197347321559] * 1 + [0.202461342545] * 1 + [0.225390187901] * 1,
+                                   samplingFraction = [0.303451138049] * 1 + [0.111872504159] * 1 + [0.135806495306] * 1 + [0.151772636618] * 1 + [0.163397436122] * 1 + [0.172566977313] * 1 + [0.179855253903] * 1 + [0.186838417657] * 1 + [0.192865946689] * 1 + [0.197420241611] * 1 + [0.202066552306] * 1 + [0.22646764465] * 1,
                                    readoutName = ecalBarrelReadoutName,
                                    layerFieldName = "layer")
 

--- a/Reconstruction/RecFCCeeCalorimeter/options/runCaloSim.py
+++ b/Reconstruction/RecFCCeeCalorimeter/options/runCaloSim.py
@@ -49,7 +49,7 @@ detectors_to_use=[
                   ]
 # prefix all xmls with path_to_detector
 geoservice.detectors = [os.path.join(path_to_detector, _det) for _det in detectors_to_use]
-geoservice.OutputLevel = WARNING
+geoservice.OutputLevel = INFO
 
 # Geant4 service
 # Configures the Geant simulation: geometry, physics list and user actions
@@ -106,7 +106,7 @@ geantsim = SimG4Alg("SimG4Alg",
 from Configurables import CalibrateInLayersTool
 calibEcalBarrel = CalibrateInLayersTool("CalibrateECalBarrel",
                                    # sampling fraction obtained using SamplingFractionInLayers from DetStudies package
-                                   samplingFraction =  [0.24833] * 1 + [0.09482] * 1  +  [0.12242] * 1  +  [0.14182] * 1  +  [0.15667] * 1  +  [0.16923] * 1  +  [0.17980] * 1  +  [0.20085] * 1,
+                                   samplingFraction = [0.306224547517] * 1 + [0.111664096145] * 1 + [0.135828948734] * 1 + [0.151690753987] * 1 + [0.163564788854] * 1 + [0.172627758875] * 1 + [0.180023941499] * 1 + [0.186642705553] * 1 + [0.192229484697] * 1 + [0.197347321559] * 1 + [0.202461342545] * 1 + [0.225390187901] * 1,
                                    readoutName = ecalBarrelReadoutName,
                                    layerFieldName = "layer")
 


### PR DESCRIPTION
- Higher granularity for the FCC-ee LAr ECAL (12 layers instead of 8)
- Updated geometry to reflect the most up to date version of the detector design (LAr gap size, absorbed size, inner radius, number of plates, ...)
- Introduction of the detector segmentation based on constant theta steps instead of constant eta steps

NB: the theta segmentation is not yet used in the default geometry because some reconstruction tools (e.g. [CaloTowerTool](https://github.com/HEP-FCC/FCCSW/blob/master/Reconstruction/RecCalorimeter/src/components/CaloTowerTool.h#L206-L207)) rely on the eta segmentation, those will have to be updated first.

The validation is based on the following tools: [FCCAnalyses calo n-tuple maker](https://github.com/BrieucF/FCCAnalyses/blob/caloNtupleizer/FCCeePerformance/Calo/analysis.py) and [performance plot maker](https://github.com/BrieucF/LAr_scripts/blob/main/caloNtupleAnalyzer/perfPlots.py).

Basic cell/cluster distributions:
![Screen Shot 2021-01-25 at 11 50 14 AM](https://user-images.githubusercontent.com/3646269/105696470-adc76a80-5f03-11eb-9204-cedab9c12a2a.png)
![Screen Shot 2021-01-25 at 11 49 44 AM](https://user-images.githubusercontent.com/3646269/105696472-ae600100-5f03-11eb-9875-5138dc470680.png)
![Screen Shot 2021-01-25 at 11 49 01 AM](https://user-images.githubusercontent.com/3646269/105696474-aef89780-5f03-11eb-9e58-fa3fbedfd8ea.png)
![Screen Shot 2021-01-25 at 11 48 26 AM](https://user-images.githubusercontent.com/3646269/105696467-ad2ed400-5f03-11eb-985b-8d15f57264c2.png)

Performance plots for the *updated* geometry (no upstream material correction applied --> energy resolution not centered around 0):

![relEresol](https://user-images.githubusercontent.com/3646269/105696677-ef581580-5f03-11eb-839f-2af1cb66603e.png)
![thetaresol](https://user-images.githubusercontent.com/3646269/105696686-f2eb9c80-5f03-11eb-82eb-fab2af8e7210.png)
![phiresol](https://user-images.githubusercontent.com/3646269/105696702-f717ba00-5f03-11eb-9a5e-7d1480ab693f.png)

Performance for the *previous* geometry (no upstream material correction applied --> energy resolution not centered around 0):

![relEresol](https://user-images.githubusercontent.com/3646269/105697014-4f4ebc00-5f04-11eb-823e-7be64034de57.png)
![thetaresol](https://user-images.githubusercontent.com/3646269/105697043-55449d00-5f04-11eb-9797-e78cce8e5ca3.png)
![phiresol](https://user-images.githubusercontent.com/3646269/105697053-58d82400-5f04-11eb-957a-0d6c545aa37d.png)


