### PR TITLE
Allow the user to manually set the seed (useful for parallel production)

### DIFF
--- a/Sim/SimG4Components/src/SimG4Svc.cpp
+++ b/Sim/SimG4Components/src/SimG4Svc.cpp
@@ -111,9 +111,15 @@ StatusCode SimG4Svc::initialize() {
     m_randSvc->engine()->seeds(seedsVec);
     long seedsList[] = {seedsVec[0], seedsVec[1]};
     CLHEP::HepRandom::setTheSeeds(seedsList);
-  }
-  info() << "Random numbers seeds: " << CLHEP::HepRandom::getTheSeeds()[0] << "\t" << CLHEP::HepRandom::getTheSeeds()[1]
+    info() << "Random numbers seeds: " << CLHEP::HepRandom::getTheSeeds()[0] << "\t" << CLHEP::HepRandom::getTheSeeds()[1]
          << endmsg;
+  }
+  else {
+    m_randSvc->engine()->setSeeds({m_seedValue});
+    std::vector<long> seedsVec;
+    m_randSvc->engine()->seeds(seedsVec);
+    info() << "Random numbers seeds: " << seedsVec << endmsg;
+  }
 
   if (!m_runManager.start()) {
     error() << "Unable to initialize GEANT correctly." << endmsg;

--- a/Sim/SimG4Components/src/SimG4Svc.h
+++ b/Sim/SimG4Components/src/SimG4Svc.h
@@ -88,6 +88,7 @@ private:
       this, "regions", {}, "Names of the tools that create regions and fast simulation models"};
   /// Flag whether random numbers seeds should be taken from Gaudi (default: true)
   Gaudi::Property<bool> m_rndmFromGaudi{this, "randomNumbersFromGaudi", true, "Whether random numbers should be taken from Gaudi"};
+  Gaudi::Property<long> m_seedValue{this, "seedValue", 1234567, "Seed to be used in RndmGenSvc engine (randomNumbersFromGaudi must be set to false)"};
 
   Gaudi::Property<bool> m_interactiveMode{this, "InteractiveMode", false, "Enter the interactive mode"};
 


### PR DESCRIPTION
This PR adds the possibility to manually set the seed used in `RndmGenSvc`. It can be used to avoid jobs starting with the same seed when launching a parallel production.