### PR TITLE
Adding links to reference documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ distribution and data persistency. This is possible due to the kind support of t
 </p>
 
 
-<h3> <strong> FCC software workshops/tutorials </strong> </h3>
+<h3 class="mt-5 mb-3"> <strong> FCC software workshops/tutorials </strong> </h3>
 
 <p>
   The next tutorial sessions about the FCC software is scheduled for 19-21 October 2022 at CERN (in-presence-only), to be confirmed on September 19th, 2022.<br>
@@ -34,9 +34,10 @@ List of previous workshop/tutorial events::
   </ul>
 </p>
 
-<h3> Delphes Card Reference </h3>
 
-<p> A repository for Delphes cards is avilable in the <a href="https://github.com/delphes/delphes/tree/master/card"s> GitHub repository </a> of the project, where example for many detector concepts exist.
+<h3 class="mt-5 mb-3"> Delphes Card Reference </h3>
+
+<p> A repository for Delphes cards is available in the <a href="https://github.com/delphes/delphes/tree/master/card"s> GitHub repository </a> of the project, where example for many detector concepts exist.
 <p>
   The Delphes cards used for the FCC-hh CDR and HL/HE-LHC yellow reports can be found here:
   <ul>
@@ -48,29 +49,46 @@ Delphes cards for the most common solutions for future e+e- experiment detectors
 and available on lxplus at /eos/project/f/fccsw-web/www/delphescards (where relevant these cards are taken from
 the <a href="https://github.com/delphes/delphes/tree/master/cards"> GitHub Delphes repository</a>).
 
-<h3>Conceptual Design Report</h3>
+
+<h3 class="mt-5 mb-3">Conceptual Design Report</h3>
 The <a href="http://fcc-cdr.web.cern.ch/">summary volumes</a> have been released, with many
 physics and detector simulations carried out in FCCSW! We collaborate with CERN's <a
 href="http://www.reanahub.io/">Re-usable Analysis</a> working group to make the workflows used in
 the CDR reproducible and accessible for future studies. <a href="https://github.com/reanahub/reana-demo-fcchh-fullsim" >Here</a> is a first example of a full-simulation
 workflow.
 
-<h3>Documentation, Tutorials and Getting Started:</h3>
+
+<h3 class="mt-5 mb-3">Documentation, Tutorials and Getting Started</h3>
+
 <p>
-All developments happen on <a href="https://github.com/HEP-FCC">github.com/HEP-FCC</a>. The best place to check
-for detailed information on a specific package thus is usually its homepage / github repository page. To get an
-  overview, there are some tutorials that may be helpful. Finally, there is a <a
-  href="http://cern.ch/simba3/SelfSubscription.aspx?groupName=fcc-experiments-sw-dev">mailing list
-  </a> for any questions
-  and suggestions. 
-<br><br>
+  All developments happen on
+  <a href="https://github.com/HEP-FCC">github.com/HEP-FCC</a> and
+  <a href="https://github.com/key4hep">github.com/key4hep</a>.
+  The best place to check for detailed information on a specific package thus is
+  usually its homepage / github repository page. To get an overview, there are
+  some tutorials that may be helpful. Finally, there is a
+  <a href="http://cern.ch/simba3/SelfSubscription.aspx?groupName=fcc-experiments-sw-dev">mailing list</a>
+  for any questions and suggestions.
 </p>
 
-</p>
-<p>
-<b>Tutorials:</b><br>
+<h4 class="mt-3">Tutorials</h4>
+
 <ul>
-  <li>see the <a href="https://hep-fcc.github.io/fcc-tutorials">tutorials section.</a></li>
+  <li>
+    Tutorial material used during the FCCSW Workshops can be found
+    <a href="https://hep-fcc.github.io/fcc-tutorials">here</a>.
+  </li>
 </ul>
-</p>
 
+<h4 class="mt-3">Reference documentation</h4>
+
+<ul>
+  <li>
+    <a href="https://hep-fcc.github.io/FCCAnalyses/doc/latest/">FCCAnalyses</a>:
+    Common framework for FCC related analyses.
+  </li>
+  <li>
+    <a href="https://hep-fcc.github.io/k4SimGeant4/">k4SimGeant4</a>:
+    Gaudi components for Geant4 simulation in the Key4HEP software framework.
+  </li>
+</ul>


### PR DESCRIPTION
Addresses Missing reference documentation.

Changes proposed in this pull-request:

- Adds links to the FCCAnalyses and k4SimGeant4 ref.documentation