### PR TITLE
Removing CentOs7 from CI

### DIFF
--- a/.github/workflows/key4hep-build.yaml
+++ b/.github/workflows/key4hep-build.yaml
@@ -6,7 +6,8 @@ on:
     - master
   pull_request:
   schedule:
-    - cron: '0 0 * * SAT'
+    # - cron: '0 3 * * 6'  # 03:00 Saturday
+    - cron: '0 3 * * *'  # 03:00 every day
   workflow_dispatch:
 
 jobs:
@@ -14,7 +15,7 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22", "centos7"]
+        image: ["alma9", "ubuntu22"]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Addresses: CentOs7 is EOL and won't be supported in upcoming key4hep stack releases.
