### PR TITLE
Removing EventCounter from the tests

### DIFF
--- a/Examples/options/geant_fullsim_fccee_lar_pgun.py
+++ b/Examples/options/geant_fullsim_fccee_lar_pgun.py
@@ -273,10 +273,4 @@ resegmentEcalBarrel.AuditExecute = True
 createEcalBarrelCells.AuditExecute = True
 createHcalBarrelCells.AuditExecute = True
 out.AuditExecute = True
-#ApplicationMgr().ExtSvc += [audsvc]
-
-from Configurables import EventCounter
-event_counter = EventCounter('event_counter')
-event_counter.Frequency = 10
-ApplicationMgr().TopAlg += [event_counter]
-
+# ApplicationMgr().ExtSvc += [audsvc]


### PR DESCRIPTION
Addresses failing test because of missing event counter in the latest stacks.