### PR TITLE
Using fixed font size in the logo for the largest breakpoint

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -48,7 +48,7 @@ article pre {
 }
 @include media-breakpoint-up(xxl) {
   .fcc-logo {
-    font-size: 4vw;
+    font-size: 80px;
   }
 }
 


### PR DESCRIPTION
Addresses too large font in the main page logo for some screen sizes (full 4K).