### PR TITLE
Fix tests.

### DIFF
--- a/.github/workflows/key4hep-build.yaml
+++ b/.github/workflows/key4hep-build.yaml
@@ -15,7 +15,10 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22"]
+        image: ["alma9"]
+        include:
+          - build_type: nightly
+            image: ubuntu24
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/Examples/options/export_detector_gdml.py
+++ b/Examples/options/export_detector_gdml.py
@@ -12,10 +12,10 @@ app.OutputLevel = INFO
 # DD4hep geometry service
 from Configurables import GeoSvc
 ## parse the given xml file
-path_to_detectors = os.environ.get("FCCDETECTORS", "")
+path_to_detectors = os.environ.get("K4GEO", "")
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [
-                          os.path.join(path_to_detectors, 'Detector/DetFCCeeCLD/compact/FCCee_o2_v02/FCCee_o2_v02.xml'),
+                          os.path.join(path_to_detectors, 'FCCee/CLD/compact/CLD_o2_v08/CLD_o2_v08.xml'),
                        ]
 ApplicationMgr().ExtSvc += [geoservice]
 

--- a/Examples/options/geant_fullsim_fccee_cld_hepevt.py
+++ b/Examples/options/geant_fullsim_fccee_cld_hepevt.py
@@ -25,10 +25,10 @@ ApplicationMgr().TopAlg += [reader]
 # DD4hep geometry service
 from Configurables import GeoSvc
 ## parse the given xml file
-path_to_detectors = os.environ.get("FCCDETECTORS", "")
+path_to_detectors = os.environ.get("K4GEO", "")
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [
-                          os.path.join(path_to_detectors, 'Detector/DetFCCeeCLD/compact/FCCee_o2_v02/FCCee_o2_v02.xml'),
+                          os.path.join(path_to_detectors, 'FCCee/CLD/compact/CLD_o2_v08/CLD_o2_v08.xml'),
                        ]
 
 

--- a/Examples/options/geant_fullsim_fccee_cld_pgun.py
+++ b/Examples/options/geant_fullsim_fccee_cld_pgun.py
@@ -40,10 +40,10 @@ ApplicationMgr().TopAlg += [hepmc_converter]
 # DD4hep geometry service
 from Configurables import GeoSvc
 ## parse the given xml file
-path_to_detectors = os.environ.get("FCCDETECTORS", "")
+path_to_detectors = os.environ.get("K4GEO", "")
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [
-                          os.path.join(path_to_detectors, 'Detector/DetFCCeeCLD/compact/FCCee_o2_v02/FCCee_o2_v02.xml'),
+                          os.path.join(path_to_detectors, 'FCCee/CLD/compact/CLD_o2_v08/CLD_o2_v08.xml'),
                        ]
 ApplicationMgr().ExtSvc += [geoservice]
 

--- a/Examples/options/geant_fullsim_fccee_idea_hepevt.py
+++ b/Examples/options/geant_fullsim_fccee_idea_hepevt.py
@@ -23,10 +23,10 @@ ApplicationMgr().TopAlg += [reader]
 # DD4hep geometry service
 from Configurables import GeoSvc
 ## parse the given xml file
-path_to_detectors = os.environ.get("FCCDETECTORS", "")
+path_to_detectors = os.environ.get("K4GEO", "")
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [
-                          os.path.join(path_to_detectors, 'Detector/DetFCCeeIDEA/compact/FCCee_DectMaster.xml'),
+                          os.path.join(path_to_detectors, 'FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml'),
                        ]
 ApplicationMgr().ExtSvc += [geoservice]
 
@@ -36,20 +36,20 @@ geantsim.outputs = []
 
 from Configurables import SimG4SaveTrackerHits
 savetrackertool = SimG4SaveTrackerHits("saveTrackerHits_Barrel")
-savetrackertool.readoutNames = ["VertexBarrelCollection"]
+savetrackertool.readoutName = "VertexBarrelCollection"
 savetrackertool.SimTrackHits.Path = "TrackerHits_barrel"
 geantsim.outputs += [savetrackertool]
 
 from Configurables import SimG4SaveTrackerHits
 savetrackertool_endcap = SimG4SaveTrackerHits("saveTrackerHits_Endcap")
-savetrackertool_endcap.readoutNames = ["VertexEndcapCollection"]
+savetrackertool_endcap.readoutName = "VertexEndcapCollection"
 savetrackertool_endcap.SimTrackHits.Path = "positionedHits_endcap"
 geantsim.outputs += [savetrackertool_endcap]
 
 
 from Configurables import SimG4SaveTrackerHits
 savetrackertool_DCH = SimG4SaveTrackerHits("saveTrackerHits_DCH")
-savetrackertool_DCH.readoutNames = ["SimplifiedDriftChamberCollection"]
+savetrackertool_DCH.readoutName = "DCHCollection"
 savetrackertool_DCH.SimTrackHits.Path = "positionedHits_DCH"
 geantsim.outputs += [savetrackertool_DCH]
 
@@ -59,11 +59,6 @@ field.FieldOn = True
 field.IntegratorStepper = "ClassicalRK4"
 field.FieldComponentZ = 2*units.tesla
 field.MaximumStep = 10000.0
-
-from Configurables import SimG4UserLimitRegion
-regiontool = SimG4UserLimitRegion("limits")
-regiontool.volumeNames = ["CDCH"]
-regiontool.maxStep = 2*units.mm
 
 from Configurables import SimG4UserLimitPhysicsList
 physicslisttool = SimG4UserLimitPhysicsList("Physics")
@@ -78,7 +73,6 @@ geantservice = SimG4Svc("SimG4Svc")
 geantservice.detector = 'SimG4DD4hepDetector'
 geantservice.physicslist = physicslisttool
 geantservice.actions = actions
-geantservice.regions = [regiontool]
 geantservice.magneticField= field
 geantservice.g4PostInitCommands +=["/process/eLoss/minKinEnergy 1 MeV"]
 geantservice.g4PostInitCommands  += ["/tracking/storeTrajectory 1"]

--- a/Examples/options/geant_fullsim_fccee_idea_pgun.py
+++ b/Examples/options/geant_fullsim_fccee_idea_pgun.py
@@ -16,10 +16,10 @@ ApplicationMgr().ExtSvc += [podioevent]
 # DD4hep geometry service
 from Configurables import GeoSvc
 ## parse the given xml file
-path_to_detectors = os.environ.get("FCCDETECTORS", "")
+path_to_detectors = os.environ.get("K4GEO", "")
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [
-                          os.path.join(path_to_detectors, 'Detector/DetFCCeeIDEA/compact/FCCee_DectMaster.xml'),
+                          os.path.join(path_to_detectors, 'FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml'),
                        ]
 ApplicationMgr().ExtSvc += [geoservice]
 
@@ -28,20 +28,20 @@ SimG4Alg("SimG4Alg").outputs = []
 
 from Configurables import SimG4SaveTrackerHits
 savetrackertool = SimG4SaveTrackerHits("saveTrackerHits_Barrel")
-savetrackertool.readoutNames = ["VertexBarrelCollection"]
+savetrackertool.readoutName = "VertexBarrelCollection"
 savetrackertool.SimTrackHits.Path = "TrackerHits_barrel"
 SimG4Alg("SimG4Alg").outputs += [savetrackertool]
 
 from Configurables import SimG4SaveTrackerHits
 savetrackertool_endcap = SimG4SaveTrackerHits("saveTrackerHits_Endcap")
-savetrackertool_endcap.readoutNames = ["VertexEndcapCollection"]
+savetrackertool_endcap.readoutName = "VertexEndcapCollection"
 savetrackertool_endcap.SimTrackHits.Path = "positionedHits_endcap"
 SimG4Alg("SimG4Alg").outputs += [savetrackertool_endcap]
 
 
 from Configurables import SimG4SaveTrackerHits
 savetrackertool_DCH = SimG4SaveTrackerHits("saveTrackerHits_DCH")
-savetrackertool_DCH.readoutNames = ["SimplifiedDriftChamberCollection"]
+savetrackertool_DCH.readoutName = "DCHCollection"
 savetrackertool_DCH.SimTrackHits.Path = "positionedHits_DCH"
 SimG4Alg("SimG4Alg").outputs += [savetrackertool_DCH]
 
@@ -51,11 +51,6 @@ field.FieldOn = True
 field.IntegratorStepper = "ClassicalRK4"
 field.FieldComponentZ = 2*units.tesla
 field.MaximumStep = 10000.0
-
-from Configurables import SimG4UserLimitRegion
-regiontool = SimG4UserLimitRegion("limits")
-regiontool.volumeNames = ["CDCH"]
-regiontool.maxStep = 2*units.mm
 
 from Configurables import SimG4UserLimitPhysicsList
 physicslisttool = SimG4UserLimitPhysicsList("Physics")
@@ -70,7 +65,6 @@ geantservice = SimG4Svc("SimG4Svc")
 geantservice.detector = 'SimG4DD4hepDetector'
 geantservice.physicslist = physicslisttool
 geantservice.actions = actions
-geantservice.regions = [regiontool]
 geantservice.magneticField= field
 geantservice.g4PostInitCommands +=["/process/eLoss/minKinEnergy 1 MeV"]
 geantservice.g4PostInitCommands  += ["/tracking/storeTrajectory 1"]


### PR DESCRIPTION
Update tests to use geometry files from k4geo, rather than the obsolete ones in FCCDetectors.  The old ones fail due to errors in the type_flags elements.  These were previously not failing because dd4hep was hiding the errors.  However, a side effect of this change

https://github.com/AIDASoft/DD4hep/pull/1578

is that dd4hep is properly reporting the errors.

Also, run the ubuntu build only with the nightly on ubuntu24.
