### PR TITLE
add action to populate pull request project table with new/reopened PRs

### DIFF
--- a/.github/workflows/add_to_fcc_pr_project.yaml
+++ b/.github/workflows/add_to_fcc_pr_project.yaml
@@ -1,0 +1,14 @@
+on:
+  workflow_call:   
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/HEP-FCC/projects/7
+          github-token: ${{ secrets.FCC_PR_PROJECT_TOKEN }}
+	  #we can eventually add label requirements
+          #labeled: needs-triage
+          #label-operator: OR

--- a/.github/workflows/fcc-prs.yaml
+++ b/.github/workflows/fcc-prs.yaml
@@ -1,0 +1,13 @@
+name: Add PR to FCC PR tracker
+
+on:
+  pull_request: 
+    types:
+      - opened
+      - reopened
+
+jobs:
+  call-ci:
+    uses: HEP-FCC/FCCSW/.github/workflows/add_to_fcc_pr_project.yml@main
+    
+      


### PR DESCRIPTION

Changes proposed in this pull-request:

- adds new action that is intended to add newly opened pull requests to https://github.com/orgs/HEP-FCC/projects/7 
- fcc-prs.yml would then be copied to any repository of potential interest (i have already added the necessary token (I hope! - to be tested) for the HEP-FCC organization)
